### PR TITLE
Update CircleCi config to deploy only when we merge to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
       - image: circleci/node:7.10
-      
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
 
     working_directory: ~/repo
 
@@ -27,6 +21,8 @@ jobs:
           name: Build
           command: yarn build
 
-      - run:
-          name: Deploy
-          command: ./node_modules/.bin/firebase deploy --token=$FIREBASE_DEPLOY_TOKEN --non-interactive
+      - deploy:
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              ./node_modules/.bin/firebase deploy --token=$FIREBASE_DEPLOY_TOKEN --non-interactive
+            fi


### PR DESCRIPTION
As a developer, I can create and push branches to github without my changes automatically deploying, so that I don't have to worry about untested code being deployed to production.