### PR TITLE
Fix bugs on transaction page

### DIFF
--- a/src/ui/transaction/CurrencyAmountStore.js
+++ b/src/ui/transaction/CurrencyAmountStore.js
@@ -8,10 +8,7 @@ class CurrencyAmountStore {
     }
 
     setAmount(amount) {
-        const float = parseCurrency(`${amount}`);
-        if(float) {
-            this._amount = float;
-        }
+        this._amount = parseCurrency(`${amount}`);
     }
 
     amount() {

--- a/src/ui/transaction/CurrencyAmountStore.test.js
+++ b/src/ui/transaction/CurrencyAmountStore.test.js
@@ -1,22 +1,29 @@
 import CurrencyAmountStore from 'ui/transaction/CurrencyAmountStore';
 
 describe('setAmount', () => {
-    it('sets the Currency amount when given a string with a valid float', () => {
+    it('sets the currency amount when given a string with a valid float', () => {
         const currencyAmountStore = new CurrencyAmountStore();
         currencyAmountStore.setAmount('123.11');
         expect(currencyAmountStore.amount()).toBeCloseTo(123.11);
     });
 
-    it('does not set the Currency amount when given a string without a valid float', () => {
+    it('does not set the currency amount when given a string without a valid float', () => {
         const currencyAmountStore = new CurrencyAmountStore();
         currencyAmountStore.setAmount('12a3.11');
         expect(currencyAmountStore.amount()).toBeNull();
     });
 
-    it('sets the Currency amount when given a float', () => {
+    it('sets the currency amount when given a float', () => {
         const currencyAmountStore = new CurrencyAmountStore();
         currencyAmountStore.setAmount(123.11);
         expect(currencyAmountStore.amount()).toBeCloseTo(123.11);
+    });
+
+    it('replaces the previous value with null if a valid float becomes invalid', () => {
+        const currencyAmountStore = new CurrencyAmountStore();
+        currencyAmountStore.setAmount('1');
+        currencyAmountStore.setAmount('1+1');
+        expect(currencyAmountStore.amount()).toBe(null);
     });
 });
 

--- a/src/ui/transaction/CurrencyInput.js
+++ b/src/ui/transaction/CurrencyInput.js
@@ -16,11 +16,11 @@ class CurrencyInput extends React.Component {
                     </InputGroupAddon>
 
                     <Input
-                        type="number"
-                        step="0.1"
-                        onChange={(event) => this._onChange(event)}
+                        type="tel"
                         placeholder="Enter transaction amount"
                         bsSize="lg"
+                        autoFocus
+                        onChange={(event) => this._onChange(event)}
                     />
                 </InputGroup>             
             </div>

--- a/src/ui/transaction/CurrencyInput.test.js
+++ b/src/ui/transaction/CurrencyInput.test.js
@@ -16,4 +16,26 @@ describe('CurrencyInput', () => {
         });
         expect(currencyAmountStore.setAmount).toHaveBeenCalledWith('123.00');
     });
+
+    it('uses a type "tel" for rendering the input so you only get the number keys on mobile', () => {
+        const currencyAmountStore = {
+            setAmount: jest.fn()
+        };
+        const currencyInput = shallow(<CurrencyInput currencyAmountStore={currencyAmountStore} />);
+        currencyInput.find(Input).simulate('change', {
+            target: { value: '123.00' }
+        });
+        expect(currencyInput.find(Input).props().type).toBe('tel');
+    });
+
+    it('autofocuses the input when rendered', () => {
+        const currencyAmountStore = {
+            setAmount: jest.fn()
+        };
+        const currencyInput = shallow(<CurrencyInput currencyAmountStore={currencyAmountStore} />);
+        currencyInput.find(Input).simulate('change', {
+            target: { value: '123.00' }
+        });
+        expect(currencyInput.find(Input).props().autoFocus).toBeTruthy();
+    });
 });


### PR DESCRIPTION
*STR*
Enter a number into transaction field followed by any character. Submit transaction.

*O*
Notice database only takes in the number before the character.

*D*
The transaction button stays disabled and does not allow submitting an invalid number.

In addition, this PR includes changes to:
1. Make the input for the transaction autofocus on page load
2. Display only number keys on mobile devices when entering a transaction