### PR TITLE
Edit daily budget

### DIFF
--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -1,3 +1,9 @@
+path / {
+    read() { false }
+    write() { false }
+}
+
+
 type Transaction {
     id: String,
     amount: Number,
@@ -15,17 +21,27 @@ type Category extends String {
     }
 }
 
-
-path / {
-    read() { false }
-    write() { false }
-}
-
 path /accounts/{userId}/transactions {
     read() { isCurrentUser(userId) }
 }
 
 path /accounts/{userId}/transactions/{transactionId} is Transaction {
+    read() { isCurrentUser(userId) }
+    write() { isCurrentUser(userId) && createOnly(this) }
+}
+
+
+type DailyBudget {
+    id: String,
+    amount: Number,
+    createdAt: String
+}
+
+path /accounts/{userId}/dailyBudgets {
+    read() { isCurrentUser(userId) }
+}
+
+path /accounts/{userId}/dailyBudgets/{dailyBudgetId} is DailyBudget {
     read() { isCurrentUser(userId) }
     write() { isCurrentUser(userId) && createOnly(this) }
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,12 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "deploy": "firebase deploy"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}",
+      "!<rootDir>/node_modules/",
+      "!src/index.js"
+    ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,16 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-
 import App from 'ui/app/App';
-import FirebaseAuthenticator from 'network/FirebaseAuthenticator';
-import FirebaseProvider from 'network/FirebaseProvider';
-import FirebaseConfigProvider from 'network/FirebaseConfigProvider';
-import Environment from 'environment/Environment';
-import AppStore from 'state/AppStore';
-import TransactionStore from 'state/TransactionStore';
-import ValueStore from 'state/ValueStore';
+import AppStoreProvider from 'state/AppStoreProvider';
 
+import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 
 import 'bootstrap/dist/css/bootstrap.css';
 import 'index.css';
 
-const appStore = _createAppStore();
+
+const appStore = AppStoreProvider.create().getAppStore();
+
 ReactDOM.render(
     <Router>
         <Route render={({location}) => (
@@ -24,27 +19,3 @@ ReactDOM.render(
     </Router>,
     document.getElementById('root')
 );
-
-
-function _createAppStore() {
-    const appStore = new AppStore();
-    const firebase = _firebase();
-    FirebaseAuthenticator.create(firebase).authenticate((user) => {
-        appStore.setUser(user);
-        appStore.setAmountStore(new ValueStore(0.0));
-        TransactionStore.create(firebase.database(), user.uid, (transactionStore) => {
-            appStore.setTransactionStore(transactionStore);
-        });
-    });
-    return appStore;
-}
-
-function _firebase() {
-    return _firebaseProvider().getFirebase();
-}
-
-function _firebaseProvider() {
-    return FirebaseProvider.create(
-        new FirebaseConfigProvider(Environment.instance())
-    );
-}

--- a/src/state/AppStore.js
+++ b/src/state/AppStore.js
@@ -4,13 +4,11 @@ import { decorate, observable, computed, action } from 'mobx';
 class AppStore {
     constructor() {
         this._user = null;
-        this._amountStore = null;
         this._transactionStore = null;
     }
 
     get initialized() {
         return this._user && 
-            this._amountStore &&
             this._transactionStore &&
             this._dailyBudgetStore;
     }
@@ -21,14 +19,6 @@ class AppStore {
 
     setUser(user) {
         this._user = user;
-    }
-
-    amountStore() {
-        return this._amountStore;
-    }
-
-    setAmountStore(amountStore) {
-        this._amountStore = amountStore;
     }
 
     transactionStore() {
@@ -51,8 +41,6 @@ class AppStore {
 export default decorate(AppStore, {
     _user: observable,
     setUser: action,
-    _amountStore: observable,
-    setAmountStore: action,
     _transactionStore: observable,
     setTransactionStore: action,
     _dailyBudgetStore: observable,

--- a/src/state/AppStore.js
+++ b/src/state/AppStore.js
@@ -9,7 +9,10 @@ class AppStore {
     }
 
     get initialized() {
-        return this._user && this._amountStore && this._transactionStore;
+        return this._user && 
+            this._amountStore &&
+            this._transactionStore &&
+            this._dailyBudgetStore;
     }
 
     user() {
@@ -35,6 +38,14 @@ class AppStore {
     setTransactionStore(transactionStore) {
         this._transactionStore = transactionStore;
     }
+
+    dailyBudgetStore() {
+        return this._dailyBudgetStore;
+    }
+
+    setDailyBudgetStore(dailyBudgetStore) {
+        this._dailyBudgetStore = dailyBudgetStore;
+    }
 };
 
 export default decorate(AppStore, {
@@ -44,5 +55,7 @@ export default decorate(AppStore, {
     setAmountStore: action,
     _transactionStore: observable,
     setTransactionStore: action,
+    _dailyBudgetStore: observable,
+    setDailyBudgetStore: action,
     initialized: computed
 });

--- a/src/state/AppStore.test.js
+++ b/src/state/AppStore.test.js
@@ -6,6 +6,7 @@ describe('initialized', () => {
         const appStore = new AppStore();
         appStore.setAmountStore({});
         appStore.setTransactionStore({});
+        appStore.setDailyBudgetStore({});
         expect(appStore.initialized).toBeFalsy();
     });
 
@@ -13,6 +14,7 @@ describe('initialized', () => {
         const appStore = new AppStore();
         appStore.setUser({});
         appStore.setAmountStore({});
+        appStore.setDailyBudgetStore({});
         expect(appStore.initialized).toBeFalsy();
     });
 
@@ -20,14 +22,24 @@ describe('initialized', () => {
         const appStore = new AppStore();
         appStore.setUser({});
         appStore.setTransactionStore({});
+        appStore.setDailyBudgetStore({});
         expect(appStore.initialized).toBeFalsy();
     });
 
-    it('returns true if the user, amount store, and transaction store are present', () => {
+    it('returns false if the daily budget store is missing', () => {
         const appStore = new AppStore();
         appStore.setUser({});
         appStore.setAmountStore({});
         appStore.setTransactionStore({});
+        expect(appStore.initialized).toBeFalsy();
+    });
+
+    it('returns true if the user, amount store, transaction store, and daily budget store are present', () => {
+        const appStore = new AppStore();
+        appStore.setUser({});
+        appStore.setAmountStore({});
+        appStore.setTransactionStore({});
+        appStore.setDailyBudgetStore({});
         expect(appStore.initialized).toBeTruthy();
     });
 });
@@ -83,5 +95,23 @@ describe('setTransactionStore', () => {
         const transactionStore = {};
         appStore.setTransactionStore(transactionStore);
         expect(appStore.transactionStore()).toEqual(transactionStore);
+    });
+});
+
+describe('dailyBudgetStore', () => {
+    it('returns the daily budget store', () => {
+        const appStore = new AppStore();
+        const dailyBudgetStore = {};
+        appStore.setDailyBudgetStore(dailyBudgetStore);
+        expect(appStore.dailyBudgetStore()).toEqual(dailyBudgetStore);
+    });
+});
+
+describe('setDailyBudgetStore', () => {
+    it('sets the daily budget store', () => {
+        const appStore = new AppStore();
+        const dailyBudgetStore = {};
+        appStore.setDailyBudgetStore(dailyBudgetStore);
+        expect(appStore.dailyBudgetStore()).toEqual(dailyBudgetStore);
     });
 });

--- a/src/state/AppStore.test.js
+++ b/src/state/AppStore.test.js
@@ -4,7 +4,6 @@ import AppStore from 'state/AppStore';
 describe('initialized', () => {
     it('returns false if the user is missing', () => {
         const appStore = new AppStore();
-        appStore.setAmountStore({});
         appStore.setTransactionStore({});
         appStore.setDailyBudgetStore({});
         expect(appStore.initialized).toBeFalsy();
@@ -13,15 +12,6 @@ describe('initialized', () => {
     it('returns false if the transaction store is missing', () => {
         const appStore = new AppStore();
         appStore.setUser({});
-        appStore.setAmountStore({});
-        appStore.setDailyBudgetStore({});
-        expect(appStore.initialized).toBeFalsy();
-    });
-
-    it('returns false if the amount store is missing', () => {
-        const appStore = new AppStore();
-        appStore.setUser({});
-        appStore.setTransactionStore({});
         appStore.setDailyBudgetStore({});
         expect(appStore.initialized).toBeFalsy();
     });
@@ -29,15 +19,13 @@ describe('initialized', () => {
     it('returns false if the daily budget store is missing', () => {
         const appStore = new AppStore();
         appStore.setUser({});
-        appStore.setAmountStore({});
         appStore.setTransactionStore({});
         expect(appStore.initialized).toBeFalsy();
     });
 
-    it('returns true if the user, amount store, transaction store, and daily budget store are present', () => {
+    it('returns true if the user, transaction store, and daily budget store are present', () => {
         const appStore = new AppStore();
         appStore.setUser({});
-        appStore.setAmountStore({});
         appStore.setTransactionStore({});
         appStore.setDailyBudgetStore({});
         expect(appStore.initialized).toBeTruthy();
@@ -59,24 +47,6 @@ describe('setUser', () => {
         const user = {};
         appStore.setUser(user);
         expect(appStore.user()).toEqual(user);
-    });
-});
-
-describe('amountStore', () => {
-    it('returns the amount store', () => {
-        const appStore = new AppStore();
-        const amountStore = {};
-        appStore.setAmountStore(amountStore);
-        expect(appStore.amountStore()).toEqual(amountStore);
-    });
-});
-
-describe('setAmountStore', () => {
-    it('sets the amount store', () => {
-        const appStore = new AppStore();
-        const amountStore = {};
-        appStore.setAmountStore(amountStore);
-        expect(appStore.amountStore()).toEqual(amountStore);
     });
 });
 

--- a/src/state/AppStoreProvider.js
+++ b/src/state/AppStoreProvider.js
@@ -1,7 +1,6 @@
 import AppStore from 'state/AppStore';
 import TransactionStore from 'state/TransactionStore';
 import DailyBudgetStore from 'state/DailyBudgetStore';
-import ValueStore from 'state/ValueStore';
 import FirebaseConfigProvider from 'network/FirebaseConfigProvider';
 import FirebaseProvider from 'network/FirebaseProvider';
 import FirebaseAuthenticator from 'network/FirebaseAuthenticator';
@@ -42,7 +41,6 @@ export default class AppStoreProvider {
 
     _startAppStoreInitialization(user, appStore) {
         appStore.setUser(user);
-        appStore.setAmountStore(new ValueStore(0.0));
         this._transactionStoreClass.create(
             this._firebase.database(),
             user.uid,

--- a/src/state/AppStoreProvider.js
+++ b/src/state/AppStoreProvider.js
@@ -1,0 +1,52 @@
+import AppStore from 'state/AppStore';
+import TransactionStore from 'state/TransactionStore';
+import ValueStore from 'state/ValueStore';
+import FirebaseConfigProvider from 'network/FirebaseConfigProvider';
+import FirebaseProvider from 'network/FirebaseProvider';
+import FirebaseAuthenticator from 'network/FirebaseAuthenticator';
+import Environment from 'environment/Environment';
+
+
+export default class AppStoreProvider {
+    static create() {
+        const firebase = this._firebase();
+        const firebaseAuthenticator = FirebaseAuthenticator.create(firebase);
+        return new AppStoreProvider(firebase, firebaseAuthenticator, TransactionStore);
+    }
+    
+    static _firebase() {
+        return this._firebaseProvider().getFirebase();
+    }
+    
+    static _firebaseProvider() {
+        return FirebaseProvider.create(
+            new FirebaseConfigProvider(Environment.instance())
+        );
+    }
+    
+    constructor(firebase, firebaseAuthenticator, transactionStoreClass) {
+        this._firebase = firebase;
+        this._firebaseAuthenticator = firebaseAuthenticator;
+        this._transactionStoreClass = transactionStoreClass;
+    }
+
+    getAppStore() {
+        const appStore = new AppStore();
+        this._firebaseAuthenticator.authenticate((user) => {
+            this._startAppStoreInitialization(user, appStore);
+        });
+        return appStore;       
+    }
+
+    _startAppStoreInitialization(user, appStore) {
+        appStore.setUser(user);
+        appStore.setAmountStore(new ValueStore(0.0));
+        this._transactionStoreClass.create(
+            this._firebase.database(),
+            user.uid,
+            (transactionStore) => {
+                appStore.setTransactionStore(transactionStore);
+            }
+        );
+    }
+}

--- a/src/state/AppStoreProvider.js
+++ b/src/state/AppStoreProvider.js
@@ -1,5 +1,6 @@
 import AppStore from 'state/AppStore';
 import TransactionStore from 'state/TransactionStore';
+import DailyBudgetStore from 'state/DailyBudgetStore';
 import ValueStore from 'state/ValueStore';
 import FirebaseConfigProvider from 'network/FirebaseConfigProvider';
 import FirebaseProvider from 'network/FirebaseProvider';
@@ -11,7 +12,7 @@ export default class AppStoreProvider {
     static create() {
         const firebase = this._firebase();
         const firebaseAuthenticator = FirebaseAuthenticator.create(firebase);
-        return new AppStoreProvider(firebase, firebaseAuthenticator, TransactionStore);
+        return new AppStoreProvider(firebase, firebaseAuthenticator, TransactionStore, DailyBudgetStore);
     }
     
     static _firebase() {
@@ -24,10 +25,11 @@ export default class AppStoreProvider {
         );
     }
     
-    constructor(firebase, firebaseAuthenticator, transactionStoreClass) {
+    constructor(firebase, firebaseAuthenticator, transactionStoreClass, dailyBudgetStoreClass) {
         this._firebase = firebase;
         this._firebaseAuthenticator = firebaseAuthenticator;
         this._transactionStoreClass = transactionStoreClass;
+        this._dailyBudgetStoreClass = dailyBudgetStoreClass;
     }
 
     getAppStore() {
@@ -46,6 +48,13 @@ export default class AppStoreProvider {
             user.uid,
             (transactionStore) => {
                 appStore.setTransactionStore(transactionStore);
+            }
+        );
+        this._dailyBudgetStoreClass.create(
+            this._firebase.database(),
+            user.uid,
+            (dailyBudgetStore) => {
+                appStore.setDailyBudgetStore(dailyBudgetStore);
             }
         );
     }

--- a/src/state/AppStoreProvider.test.js
+++ b/src/state/AppStoreProvider.test.js
@@ -37,13 +37,14 @@ describe('getAppStore', () => {
             authenticate: authenticate
         };
 
-        const create = jest.fn();
-        const transactionStoreClass = { create: create };
+        const transactionStoreClass = { create: jest.fn() };
+        const dailyBudgetStoreClass = { create: jest.fn() };
 
         const appStoreProvider = new AppStoreProvider(
             firebase,
             firebaseAuthenticator,
-            transactionStoreClass
+            transactionStoreClass,
+            dailyBudgetStoreClass
         );
         const appStore = appStoreProvider.getAppStore();
 
@@ -51,7 +52,10 @@ describe('getAppStore', () => {
         authenticate.mock.calls[0][0](user);
 
         const transactionStore = {};
-        create.mock.calls[0][2](transactionStore);
+        transactionStoreClass.create.mock.calls[0][2](transactionStore);
+        
+        const dailyBudgetStore = {};
+        dailyBudgetStoreClass.create.mock.calls[0][2](dailyBudgetStore);
 
         expect(appStore.initialized).toBeTruthy();
     });

--- a/src/state/AppStoreProvider.test.js
+++ b/src/state/AppStoreProvider.test.js
@@ -1,0 +1,58 @@
+import AppStoreProvider from 'state/AppStoreProvider';
+
+
+describe('create', () => {
+    it('returns a new instance of AppStoreProvider', () => {
+        const appStoreProvider = AppStoreProvider.create();
+        expect(appStoreProvider).toBeInstanceOf(AppStoreProvider);
+    });
+}); 
+
+describe('getAppStore', () => {
+    it('returns an AppStore that is in the process of initializing', () => {
+        const auth = jest.fn(() => ({
+            onAuthStateChanged: jest.fn()
+        }));
+        const firebase = {
+            auth: auth
+        };
+
+        const authenticate = jest.fn();
+        const firebaseAuthenticator = {
+            authenticate: authenticate
+        };
+        const appStoreProvider = new AppStoreProvider(firebase, firebaseAuthenticator, {});
+        const appStore = appStoreProvider.getAppStore();
+
+        expect(appStore.initialized).toBeFalsy();
+    });
+
+    it('returns an AppStore that eventually completes initialization', () => {
+        const ref = jest.fn();
+        const database = jest.fn(() => { ref: ref });
+        const firebase = { database: database };     
+        
+        const authenticate = jest.fn();
+        const firebaseAuthenticator = {
+            authenticate: authenticate
+        };
+
+        const create = jest.fn();
+        const transactionStoreClass = { create: create };
+
+        const appStoreProvider = new AppStoreProvider(
+            firebase,
+            firebaseAuthenticator,
+            transactionStoreClass
+        );
+        const appStore = appStoreProvider.getAppStore();
+
+        const user = { uid: '123' };
+        authenticate.mock.calls[0][0](user);
+
+        const transactionStore = {};
+        create.mock.calls[0][2](transactionStore);
+
+        expect(appStore.initialized).toBeTruthy();
+    });
+});

--- a/src/state/Budget.js
+++ b/src/state/Budget.js
@@ -1,11 +1,14 @@
+import BudgetAccumulator from 'state/BudgetAccumulator';
+
+
 export default class Budget {
-    static create(accrual_rate, transactions) {
-        return new Budget(new Date(), accrual_rate, transactions);
+    static create(dailyBudgets, transactions) {
+        return new Budget(new Date(), dailyBudgets, transactions);
     }
 
-    constructor(date, accrual_rate, transactions) {
+    constructor(date, dailyBudgets, transactions) {
         this._date = date;
-        this._accrual_rate = accrual_rate;
+        this._dailyBudgets = dailyBudgets;
         this._transactions = transactions;
     }
 
@@ -14,7 +17,7 @@ export default class Budget {
     }
 
     _amountAccrued() {
-        return this._date.getDate() * this._accrual_rate;
+        return (new BudgetAccumulator(this._dailyBudgets)).monthToDate(this._date);
     }
 
     _amountSpent() {

--- a/src/state/Budget.test.js
+++ b/src/state/Budget.test.js
@@ -1,62 +1,75 @@
 import Budget from 'state/Budget';
+import DailyBudget from 'state/DailyBudget';
 import Transaction from 'state/Transaction';
 
 
 describe('create', () => {
     it('returns a budget configured with the current date', () => {
         const savedDate = Date;
-        const today = new Date(2018, 2, 5);
-        const transactions = [new Transaction('id1', 10.00, new Date(2018, 2, 1), 'Disneyland')];
+        const today = new Date('2018-04-05T11:00:00.000Z');
+
+        const dailyBudgets = [
+            new DailyBudget('id1', 8.00, new Date('2018-04-01T11:00:00.000Z'))
+        ];
+        const transactions = [
+            new Transaction('id1', 10.00, new Date('2018-04-02T11:00:00.000Z'), 'Disneyland')
+        ];
         
         // Mock the date constructor and restore it after creating a budget
         Date = jest.fn(() => today);
-        const budget = Budget.create(10.00, transactions);
+        const budget = Budget.create(dailyBudgets, transactions);
         Date = savedDate;
 
-        expect(budget.current()).toBeCloseTo(40.00);
+        expect(budget.current()).toBeCloseTo(22.00);
     });
 });
 
 describe('current', () => {
     it('returns the amount accrued minus the amount spent', () => {
-        const today = new Date(2018, 2, 1);
+        const today = new Date('2018-04-02T11:00:00.000Z');;
         
+        const dailyBudgets = [
+            new DailyBudget('id1', 40.00, new Date('2018-04-01T11:00:00.000Z'))
+        ];
         const transactions = [
-            new Transaction('id1', 10.00, new Date(2018, 2, 1), 'Disneyland'),
-            new Transaction('id2', 15.00, new Date(2018, 2, 2), 'Knotts')
+            new Transaction('id1', 10.00, new Date('2018-04-01T11:00:00.000Z'), 'Disneyland'),
+            new Transaction('id2', 15.00, new Date('2018-04-02T11:00:00.000Z'), 'Knotts')
         ];
 
-        const budget = new Budget(today, 40.00, transactions);
+        const budget = new Budget(today, dailyBudgets, transactions);
         expect(budget.current()).toBeCloseTo(15.00);
     });
 
     it('ignores transactions from a previous month', () => {
-        const today = new Date(2018, 2, 1);
+        const today = new Date('2018-04-02T11:00:00.000Z');;
         
+        const dailyBudgets = [
+            new DailyBudget('id1', 40.00, new Date('2018-01-01T11:00:00.000Z'))
+        ];
         const transactions = [
-            new Transaction('id1', 10.00, new Date(2018, 1, 1), 'Disneyland'),
-            new Transaction('id2', 15.00, new Date(2018, 2, 2), 'Knotts')
+            new Transaction('id1', 10.00, new Date('2018-01-01T11:00:00.000Z'), 'Disneyland'),
+            new Transaction('id2', 15.00, new Date('2018-04-02T11:00:00.000Z'), 'Knotts')
         ];
 
-        const budget = new Budget(today, 20.00, transactions);
-        expect(budget.current()).toBeCloseTo(5.00);
+        const budget = new Budget(today, dailyBudgets, transactions);
+        expect(budget.current()).toBeCloseTo(65.00);
     });
 
-    it('returns the accrual rate on the first day of the month', () => {
-        const today = new Date(2018, 2, 1);
-        const budget = new Budget(today, 40.00, []);
-        expect(budget.current()).toBeCloseTo(40.00);
+    it('adjusts accrual rate over the course of a month based on daily budget updates', () => {
+        const today = new Date('2018-04-07T11:00:00.000Z');;
+        
+        const dailyBudgets = [
+            new DailyBudget('id1', 40.00, new Date('2018-01-01T11:00:00.000Z')),
+            new DailyBudget('id2', 10.00, new Date('2018-04-03T11:00:00.000Z')),
+            new DailyBudget('id3', 3000.00, new Date('2018-04-05T11:00:00.000Z'))
+        ];
+        const transactions = [
+            new Transaction('id1', 10.00, new Date('2018-04-02T11:00:00.000Z'), 'Disneyland'),
+            new Transaction('id2', 15.00, new Date('2018-04-03T11:00:00.000Z'), 'Knotts')
+        ];
+
+        const budget = new Budget(today, dailyBudgets, transactions);
+        expect(budget.current()).toBeCloseTo(6115.00);
     });
 
-    it('returns the accrual rate * 2 on the second day of the month', () => {
-        const today = new Date(2018, 2, 2);
-        const budget = new Budget(today, 40.00, []);
-        expect(budget.current()).toBeCloseTo(80.00);
-    });
-
-    it('returns the accrual rate * 31 on the 31st day of the month', () => {
-        const today = new Date(2018, 2, 31);
-        const budget = new Budget(today, 40.00, []);
-        expect(budget.current()).toBeCloseTo(31 * 40.00);
-    });
 });

--- a/src/state/BudgetAccumulator.js
+++ b/src/state/BudgetAccumulator.js
@@ -1,0 +1,52 @@
+export default class BudgetAccumulator {
+    constructor(dailyBudgets) {
+        this._dailyBudgets = dailyBudgets;
+    }
+
+    monthToDate(date) {
+        if(this._dailyBudgets.length === 0) {
+            return 0.00;
+        }
+        
+        const dailyBudgets = this._dailyBudgets.slice();
+        const startDate = this._dailyBudgets[0].createdAt();
+        
+        let amount = 0.00;
+        let dailyBudget = null;
+        this._forEachDateBetween(startDate, date, (currDate) => {
+            while(dailyBudgets.length > 0 && this._afterDay(currDate, dailyBudgets[0].createdAt())) {
+                dailyBudget = dailyBudgets.shift();
+            }
+            if(dailyBudget !== null && this._sameMonth(currDate, date)) {
+                amount += dailyBudget.amount();
+            }
+        });
+        return amount;
+    }
+
+    _forEachDateBetween(start, end, func) {        
+        let curr = new Date(start);
+        while(curr < end || this._sameDay(curr, end)) {
+            func(curr);
+            curr.setDate(curr.getDate() + 1);
+        }
+    }
+
+    _afterDay(date1, date2) {
+        return !this._sameDay(date1, date2) && date1 > date2;
+    }
+
+    _sameDay(date1, date2) {
+        return(
+            this._sameMonth(date1, date2) &&
+            date1.getDate() === date2.getDate()
+        );
+    }
+
+    _sameMonth(date1, date2) {
+        return(
+            date1.getFullYear() === date2.getFullYear() &&
+            date1.getMonth() === date2.getMonth()
+        );
+    }
+}

--- a/src/state/BudgetAccumulator.test.js
+++ b/src/state/BudgetAccumulator.test.js
@@ -1,0 +1,112 @@
+import BudgetAccumulator from 'state/BudgetAccumulator';
+import DailyBudget from 'state/DailyBudget';
+
+
+describe('monthToDate', () => {
+    it('returns 10.00 for one day with a daily budget of 10.00', () => {
+        const april1 = new Date('2018-04-01T11:00:00.000Z');
+        const april2 = new Date('2018-04-02T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([new DailyBudget('id1', 10.00, april1)]);
+        expect(accumulator.monthToDate(april2)).toBeCloseTo(10.00);
+    });
+
+    it('returns 20.00 for two days with a daily budget of 10.00', () => {
+        const april1 = new Date('2018-04-01T11:00:00.000Z');
+        const april3 = new Date('2018-04-03T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([new DailyBudget('id1', 10.00, april1)]);
+        expect(accumulator.monthToDate(april3)).toBeCloseTo(20.00);
+    });
+
+    it('returns 40.00 for two days with a daily budget of 20.00', () => {
+        const april1 = new Date('2018-04-01T11:00:00.000Z');
+        const april3 = new Date('2018-04-03T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([new DailyBudget('id1', 20.00, april1)]);
+        expect(accumulator.monthToDate(april3)).toBeCloseTo(40.00);
+    });
+
+    it('returns 50.00 for two days with a daily budget of 20.00 and one day with a daily budget of 10.00', () => {
+        const april1 = new Date('2018-04-01T11:00:00.000Z');
+        const april3 = new Date('2018-04-03T11:00:00.000Z');
+        const april4 = new Date('2018-04-04T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([
+            new DailyBudget('id1', 20.00, april1),
+            new DailyBudget('id2', 10.00, april3)
+        ]);
+        expect(accumulator.monthToDate(april4)).toBeCloseTo(50.00);
+    });
+
+    it('ignores obsolete daily budgets created within the same day', () => {
+        const april1 = new Date('2018-04-01T11:00:00.000Z');
+        const april2 = new Date('2018-04-02T11:00:00.000Z');
+        const april3 = new Date('2018-04-03T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([
+            new DailyBudget('id1', 20.00, april1),
+            new DailyBudget('id2', 1000.00, april2),
+            new DailyBudget('id3', 2000.00, april2),
+            new DailyBudget('id4', 37.00, april2)
+        ]);
+        expect(accumulator.monthToDate(april3)).toBeCloseTo(57.00);
+    });
+
+    it('ensures that daily budget changes do not take effect on the current day', () => {
+        const april1 = new Date('2018-04-01T11:00:00.000Z');
+        const april2 = new Date('2018-04-02T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([
+            new DailyBudget('id1', 20.00, april1),
+            new DailyBudget('id2', 1000.00, april2),
+        ]);
+        expect(accumulator.monthToDate(april2)).toBeCloseTo(20.00);
+    });
+
+    it('ignores future daily budgets', () => {
+        const april1 = new Date('2018-04-01T11:00:00.000Z');
+        const april2 = new Date('2018-04-02T11:00:00.000Z');
+        const april3 = new Date('2018-04-03T11:00:00.000Z');
+        const april4 = new Date('2018-04-04T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([
+            new DailyBudget('id1', 20.00, april1),
+            new DailyBudget('id2', 10.00, april2),
+            new DailyBudget('id3', 2000.00, april4)
+        ]);
+        expect(accumulator.monthToDate(april3)).toBeCloseTo(30.00);
+    });
+
+    it('uses the latest daily budget if no daily budgets have been added in the current month', () => {
+        const march14 = new Date('2018-03-14T00:00:00.000Z');
+        const march15 = new Date('2018-03-15T00:00:00.000Z');
+        const april2 = new Date('2018-04-02T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([
+            new DailyBudget('id1', 3000.00, march14),
+            new DailyBudget('id2', 20.00, march15)
+        ]);
+        expect(accumulator.monthToDate(april2)).toBeCloseTo(40.00);
+    });
+
+    it('returns 0.00 if no daily budget has been configured', () => {
+        const april2 = new Date('2018-04-02T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([]);
+        expect(accumulator.monthToDate(april2)).toBeCloseTo(0.00);
+    });
+
+    it('returns 0.00 if only future daily budgets exist', () => {
+        const april5 = new Date('2018-04-05T11:00:00.000Z');
+        const april20 = new Date('2018-04-20T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([
+            new DailyBudget('id3', 3000.00, april20)
+        ]);
+        expect(accumulator.monthToDate(april5)).toBeCloseTo(0.00);
+    });
+
+    it('rolls over daily budget from a previous month and adjusts to updates in the current month', () => {
+        const march15 = new Date('2018-03-15T11:00:00.000Z');
+        const april2 = new Date('2018-04-02T11:00:00.000Z');
+        const april5 = new Date('2018-04-05T11:00:00.000Z');
+        const april20 = new Date('2018-04-20T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([
+            new DailyBudget('id1', 50.00, march15),
+            new DailyBudget('id2', 20.00, april2),
+            new DailyBudget('id3', 3000.00, april20)
+        ]);
+        expect(accumulator.monthToDate(april5)).toBeCloseTo(160.00);
+    });
+});

--- a/src/state/DailyBudget.js
+++ b/src/state/DailyBudget.js
@@ -1,0 +1,19 @@
+export default class DailyBudget {
+    constructor(id, amount, createdAt) {
+        this._id = id;
+        this._amount = amount;
+        this._createdAt = createdAt;
+    }
+
+    id() {
+        return this._id;
+    }
+
+    amount() {
+        return this._amount;
+    }
+
+    createdAt() {
+        return this._createdAt;
+    }
+}

--- a/src/state/DailyBudget.test.js
+++ b/src/state/DailyBudget.test.js
@@ -1,0 +1,24 @@
+import DailyBudget from 'state/DailyBudget';
+
+
+describe('id', () => {
+    it('returns the daily budget id', () => {
+        const dailyBudget = new DailyBudget('id', 12, new Date());
+        expect(dailyBudget.id()).toBe('id');
+    });
+});
+
+describe('amount', () => {
+    it('returns the daily budget amount', () => {
+        const dailyBudget = new DailyBudget('id', 12, new Date());
+        expect(dailyBudget.amount()).toBeCloseTo(12);
+    });
+});
+
+describe('createdAt', () => {
+    it('returns the date and time the dailyBudget occurred at', () => {
+        const createdAt = new Date(2018, 2, 5);
+        const dailyBudget = new DailyBudget('id', 12, createdAt);
+        expect(dailyBudget.createdAt()).toBe(createdAt);
+    });
+});

--- a/src/state/DailyBudgetSerializer.js
+++ b/src/state/DailyBudgetSerializer.js
@@ -1,0 +1,24 @@
+import DailyBudget from 'state/DailyBudget';
+
+
+export default class DailyBudgetSerializer {
+    static toJson(dailyBudget) {
+        return {
+            id: dailyBudget.id(),
+            amount: dailyBudget.amount(),
+            createdAt: dailyBudget.createdAt().toISOString(),
+        };
+    }
+
+    static fromJson(json) {
+        return new DailyBudget(
+            json.id,
+            json.amount,
+            new Date(json.createdAt),
+        );
+    }
+
+    static fromJsonList(jsonList) {
+        return jsonList.map((json) => this.fromJson(json));
+    }
+}

--- a/src/state/DailyBudgetSerializer.test.js
+++ b/src/state/DailyBudgetSerializer.test.js
@@ -1,0 +1,51 @@
+import DailyBudgetSerializer from 'state/DailyBudgetSerializer';
+import DailyBudget from 'state/DailyBudget';
+
+
+describe('toJson', () => {
+    it('serializes the given daily budget to JSON', () => {
+        const createdAt = new Date('2018-03-05T11:24:12.000Z');
+        const dailyBudget = new DailyBudget('id1', 12, createdAt);
+        expect(DailyBudgetSerializer.toJson(dailyBudget)).toEqual({
+            id: 'id1',
+            amount: 12,
+            createdAt: '2018-03-05T11:24:12.000Z'
+        });
+    });
+});
+
+describe('fromJson', () => {
+    it('deserializes the given JSON to a daily budget', () => {
+        const createdAt = new Date('2018-03-05T11:24:12.000Z');
+        const dailyBudget = new DailyBudget('id1', 12, createdAt);
+        expect(DailyBudgetSerializer.fromJson({
+            id: 'id1',
+            amount: 12,
+            createdAt: '2018-03-05T11:24:12.000Z'
+        })).toEqual(dailyBudget);
+    });
+});
+
+describe('fromJsonList', () => {
+    it('deserializes the given list of JSONs to a list of daily budgets', () => {
+        const createdAt = new Date('2018-03-05T11:24:12.000Z');
+        const dailyBudgets = [
+            new DailyBudget('id1', 12, createdAt),
+            new DailyBudget('id2', 11, createdAt)
+        ];
+        expect(DailyBudgetSerializer.fromJsonList(
+            [
+                {
+                    id: 'id1',
+                    amount: 12,
+                    createdAt: '2018-03-05T11:24:12.000Z'
+                },
+                {
+                    id: 'id2',
+                    amount: 11,
+                    createdAt: '2018-03-05T11:24:12.000Z'
+                }
+            ]
+        )).toEqual(dailyBudgets);
+    });
+});

--- a/src/state/DailyBudgetStore.js
+++ b/src/state/DailyBudgetStore.js
@@ -1,0 +1,61 @@
+import { decorate, observable } from 'mobx';
+import DailyBudget from 'state/DailyBudget';
+import DailyBudgetSerializer from 'state/DailyBudgetSerializer';
+
+
+const DEFAULT_DAILY_BUDGET = new DailyBudget(40.00, new Date('0000-01-01T00:00:00.000Z'));
+
+class DailyBudgetStore {
+    static create(firebaseDatabase, userId, onInitialized) {
+        const dailyBudgetsRef = firebaseDatabase.ref(`/accounts/${userId}/dailyBudgets`);
+        const dailyBudgetStore = new DailyBudgetStore(dailyBudgetsRef, []);
+        this._initialize(dailyBudgetsRef, dailyBudgetStore, onInitialized);
+
+        return dailyBudgetStore;
+    }
+
+    static _initialize(dailyBudgetRef, dailyBudgetStore, onInitialized) {
+        dailyBudgetRef.on('value', (snapshot) => {
+            if(snapshot.val()) {
+                dailyBudgetStore.receiveDailyBudgets(
+                    DailyBudgetSerializer.fromJsonList(Object.values(snapshot.val()))
+                );
+            }
+            if(onInitialized) {
+                onInitialized(dailyBudgetStore);
+                onInitialized = null;
+            }
+        });
+    }
+
+    constructor(dailyBudgetsRef, dailyBudgets) {
+        this._dailyBudgetsRef = dailyBudgetsRef;
+        this._dailyBudgets = dailyBudgets;
+    }
+
+    dailyBudgets() {
+        return this._dailyBudgets.slice();
+    }
+
+    currentDailyBudget() {
+        if(this._dailyBudgets.length > 0) {
+            return this._dailyBudgets[this._dailyBudgets.length - 1];
+        } else {
+            return DEFAULT_DAILY_BUDGET;
+        }
+    }
+
+    addDailyBudget(amount, createdAt, category) {
+        const ref = this._dailyBudgetsRef.push();
+        const dailyBudget = new DailyBudget(ref.key, amount, createdAt, category);
+        ref.set(DailyBudgetSerializer.toJson(dailyBudget));
+    }
+
+    receiveDailyBudgets(dailyBudgets) {
+        this._dailyBudgets = dailyBudgets;
+    }
+}
+
+export default decorate(DailyBudgetStore, {
+    _dailyBudgets: observable
+});

--- a/src/state/DailyBudgetStore.js
+++ b/src/state/DailyBudgetStore.js
@@ -3,7 +3,7 @@ import DailyBudget from 'state/DailyBudget';
 import DailyBudgetSerializer from 'state/DailyBudgetSerializer';
 
 
-const DEFAULT_DAILY_BUDGET = new DailyBudget(40.00, new Date('0000-01-01T00:00:00.000Z'));
+const DEFAULT_DAILY_BUDGET = new DailyBudget('default', 0.00, new Date('0000-01-01T00:00:00.000Z'));
 
 class DailyBudgetStore {
     static create(firebaseDatabase, userId, onInitialized) {

--- a/src/state/DailyBudgetStore.test.js
+++ b/src/state/DailyBudgetStore.test.js
@@ -1,0 +1,133 @@
+import DailyBudgetStore from 'state/DailyBudgetStore';
+import DailyBudget from 'state/DailyBudget';
+
+
+describe('create', () => {
+    it('creates a new daily budget store and wires up the database ref', () => {
+        const firebaseDatabase = _firebaseDatabase();
+        const dailyBudgetStore = DailyBudgetStore.create(firebaseDatabase, 'john', jest.fn());
+        
+        expect(firebaseDatabase.ref).toHaveBeenCalledWith('/accounts/john/dailyBudgets');
+        expect(firebaseDatabase.ref().on).toHaveBeenCalledTimes(1);
+
+        firebaseDatabase.ref().on.mock.calls[0][1](_snapshot());
+        const dailyBudget1 = new DailyBudget('id1', 123, new Date(2018, 2, 1));
+        const dailyBudget2 = new DailyBudget('id2', 124, new Date(2018, 2, 2));
+        expect(dailyBudgetStore.dailyBudgets()).toEqual([dailyBudget1, dailyBudget2]);
+    });
+
+    it('invokes the onInitialized callback once upon first reception of daily budgets', () => {
+        const firebaseDatabase = _firebaseDatabase();
+        const onInitialized = jest.fn();
+        const dailyBudgetStore = DailyBudgetStore.create(firebaseDatabase, 'john', onInitialized);
+        
+        expect(firebaseDatabase.ref).toHaveBeenCalledWith('/accounts/john/dailyBudgets');
+        expect(firebaseDatabase.ref().on).toHaveBeenCalledTimes(1);
+
+        firebaseDatabase.ref().on.mock.calls[0][1](_snapshot());
+        expect(onInitialized).toHaveBeenCalledWith(dailyBudgetStore);
+
+        firebaseDatabase.ref().on.mock.calls[0][1](_snapshot());
+        expect(onInitialized).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles the case where the database snapshot value is null', () => {
+        const firebaseDatabase = _firebaseDatabase();
+        const dailyBudgetStore = DailyBudgetStore.create(firebaseDatabase, 'john');
+        
+        expect(firebaseDatabase.ref).toHaveBeenCalledWith('/accounts/john/dailyBudgets');
+        expect(firebaseDatabase.ref().on).toHaveBeenCalledTimes(1);
+
+        firebaseDatabase.ref().on.mock.calls[0][1]({ val: () => null });
+        expect(dailyBudgetStore.dailyBudgets()).toEqual([]);
+    });
+});
+
+describe('dailyBudgets', () => {
+    it('returns a list of daily budgets in the store', () => {
+        const dailyBudgets = [
+            new DailyBudget('id1', 11, new Date()),
+            new DailyBudget('id2', 30, new Date())
+        ];
+        const dailyBudgetStore = new DailyBudgetStore(_dailyBudgetsRef(), dailyBudgets);
+        expect(dailyBudgetStore.dailyBudgets()).toEqual(dailyBudgets);
+    });
+});
+
+describe('currentDailyBudget', () => {
+    it('returns the last (most recent) daily budget in the list', () => {
+        const dailyBudgets = [
+            new DailyBudget('id1', 11, new Date()),
+            new DailyBudget('id2', 30, new Date())
+        ];
+        const dailyBudgetStore = new DailyBudgetStore(_dailyBudgetsRef(), dailyBudgets);
+        expect(dailyBudgetStore.currentDailyBudget()).toEqual(dailyBudgets[1]);
+    });
+
+    it('returns a default daily budget with a value of 40 and the earliest time possible', () => {
+        const dailyBudgetStore = new DailyBudgetStore(_dailyBudgetsRef(), []);
+        const defaultDailyBudget = new DailyBudget(40.00, new Date('0000-01-01T00:00:00.000Z'));
+        expect(dailyBudgetStore.currentDailyBudget()).toEqual(defaultDailyBudget);
+    });
+});
+
+describe('addDailyBudget', () => {
+    it('adds a new daily budget to the firebase database', () => {
+        const dailyBudgetsRef = _dailyBudgetsRef();
+        const dailyBudgetStore = new DailyBudgetStore(dailyBudgetsRef, []);
+        const createdAt = new Date('2018-03-01T08:00:00.000Z');
+        
+        dailyBudgetStore.addDailyBudget(123.00, createdAt);
+        expect(dailyBudgetsRef.push().set).toHaveBeenCalledWith({
+            id: 'someKey',
+            amount: 123,
+            createdAt: '2018-03-01T08:00:00.000Z'
+        });
+    });
+});
+
+describe('receiveDailyBudgets', () => {
+    it('replaces daily budgets with those received from the database', () => {
+        const dailyBudgets = [
+            new DailyBudget('id1', 11, new Date()),
+            new DailyBudget('id2', 30, new Date())
+        ];
+        const dailyBudgetStore = new DailyBudgetStore(_dailyBudgetsRef(), []);
+        dailyBudgetStore.receiveDailyBudgets(dailyBudgets);
+        expect(dailyBudgetStore.dailyBudgets()).toEqual(dailyBudgets);
+    });
+});
+
+function _firebaseDatabase() {
+    const on = jest.fn();
+    return {
+        ref: jest.fn(() => ({ on: on }))
+    };
+}
+
+function _dailyBudgetsRef() {
+    const set = jest.fn();
+    return {
+        push: jest.fn(() => ({
+            key: 'someKey',
+            set: set
+        }))
+    }
+}
+
+function _snapshot() {
+    return {
+        val: () => ({
+            'id1': {
+                id: 'id1',
+                amount: 123,
+                createdAt: new Date(2018, 2, 1),
+            },
+            'id2': {
+                id: 'id2',
+                amount: 124,
+                createdAt: new Date(2018, 2, 2),
+            }
+        })
+    };
+}

--- a/src/state/DailyBudgetStore.test.js
+++ b/src/state/DailyBudgetStore.test.js
@@ -64,9 +64,9 @@ describe('currentDailyBudget', () => {
         expect(dailyBudgetStore.currentDailyBudget()).toEqual(dailyBudgets[1]);
     });
 
-    it('returns a default daily budget with a value of 40 and the earliest time possible', () => {
+    it('returns a default daily budget with a value of 0.00 and the earliest time possible', () => {
         const dailyBudgetStore = new DailyBudgetStore(_dailyBudgetsRef(), []);
-        const defaultDailyBudget = new DailyBudget(40.00, new Date('0000-01-01T00:00:00.000Z'));
+        const defaultDailyBudget = new DailyBudget('default', 0.00, new Date('0000-01-01T00:00:00.000Z'));
         expect(dailyBudgetStore.currentDailyBudget()).toEqual(defaultDailyBudget);
     });
 });

--- a/src/ui/app/App.js
+++ b/src/ui/app/App.js
@@ -39,7 +39,7 @@ class App extends React.Component {
 
     _budget() {
         return Budget.create(
-            40.00,
+            this.props.appStore.dailyBudgetStore().dailyBudgets(),
             this.props.appStore.transactionStore().transactions()
         );
     }

--- a/src/ui/app/App.test.js
+++ b/src/ui/app/App.test.js
@@ -16,7 +16,6 @@ describe('App', () => {
     it('renders AppRoutes when the user has authenticated', () => {
         const appStore = new AppStore();
         appStore.setUser(_user());
-        appStore.setAmountStore({});
         appStore.setTransactionStore(_transactionStore());
         appStore.setDailyBudgetStore(_dailyBudgetStore());
 

--- a/src/ui/app/App.test.js
+++ b/src/ui/app/App.test.js
@@ -18,6 +18,7 @@ describe('App', () => {
         appStore.setUser(_user());
         appStore.setAmountStore({});
         appStore.setTransactionStore(_transactionStore());
+        appStore.setDailyBudgetStore(_dailyBudgetStore());
 
         const app = shallow(<App appStore={appStore} location={{}} />);
         expect(app.find(AppRoutes)).toHaveLength(1);
@@ -32,6 +33,12 @@ describe('App', () => {
     function _transactionStore() {
         return {
             transactions: jest.fn()
+        };
+    }
+
+    function _dailyBudgetStore() {
+        return {
+            dailyBudgets: jest.fn()
         };
     }
 });

--- a/src/ui/app/AppRoutes.js
+++ b/src/ui/app/AppRoutes.js
@@ -39,6 +39,7 @@ class AppRoutes extends React.Component {
 
                 <Route path="/settings" render={({ history }) => (
                     <SettingsRoutes
+                        dailyBudgetStore={this.props.appStore.dailyBudgetStore()}
                         location={this.props.location} />)}
                 />
             </Switch>

--- a/src/ui/app/AppRoutes.js
+++ b/src/ui/app/AppRoutes.js
@@ -13,7 +13,6 @@ class AppRoutes extends React.Component {
     constructor(props) {
         super(props);
         this._categoryStore = new ValueStore();
-        this._dailyBudgetStore = new ValueStore();
     }
 
     render() {

--- a/src/ui/app/AppRoutes.js
+++ b/src/ui/app/AppRoutes.js
@@ -12,6 +12,7 @@ import ValueStore from 'state/ValueStore';
 class AppRoutes extends React.Component {
     constructor(props) {
         super(props);
+        this._amountStore = new ValueStore();
         this._categoryStore = new ValueStore();
     }
 
@@ -29,7 +30,7 @@ class AppRoutes extends React.Component {
                 
                 <Route path="/transactions" render={({ history }) => (
                     <TransactionAmountPage
-                        amountStore={this.props.appStore.amountStore()}
+                        amountStore={this._amountStore}
                         categoryStore={this._categoryStore}
                         transactionStore={this.props.appStore.transactionStore()}
                         history={history}

--- a/src/ui/app/AppRoutes.js
+++ b/src/ui/app/AppRoutes.js
@@ -5,8 +5,7 @@ import { Switch, Route } from 'react-router-dom';
 
 import BudgetSummaryPage from 'ui/summary/BudgetSummaryPage';
 import TransactionAmountPage from 'ui/transaction/TransactionAmountPage';
-import DailyBudgetPage from 'ui/settings/DailyBudgetPage';
-import DailyBudgetEditPage from 'ui/settings/DailyBudgetEditPage';
+import SettingsRoutes from 'ui/settings/SettingsRoutes';
 import ValueStore from 'state/ValueStore';
 
 
@@ -39,14 +38,8 @@ class AppRoutes extends React.Component {
                     />)}
                 />
 
-                <Route path="/daily_budget" render={({ history }) => (
-                    <DailyBudgetPage
-                        location={this.props.location} />)}
-                />
-
-                <Route path="/daily_budget_edit" render={({ history }) => (
-                    <DailyBudgetEditPage
-                        dailyBudgetStore={this._dailyBudgetStore}
+                <Route path="/settings" render={({ history }) => (
+                    <SettingsRoutes
                         location={this.props.location} />)}
                 />
             </Switch>

--- a/src/ui/app/AppRoutes.js
+++ b/src/ui/app/AppRoutes.js
@@ -6,6 +6,7 @@ import { Switch, Route } from 'react-router-dom';
 import BudgetSummaryPage from 'ui/summary/BudgetSummaryPage';
 import TransactionAmountPage from 'ui/transaction/TransactionAmountPage';
 import DailyBudgetPage from 'ui/settings/DailyBudgetPage';
+import DailyBudgetEditPage from 'ui/settings/DailyBudgetEditPage';
 import ValueStore from 'state/ValueStore';
 
 
@@ -13,6 +14,7 @@ class AppRoutes extends React.Component {
     constructor(props) {
         super(props);
         this._categoryStore = new ValueStore();
+        this._dailyBudgetStore = new ValueStore();
     }
 
     render() {
@@ -39,6 +41,12 @@ class AppRoutes extends React.Component {
 
                 <Route path="/daily_budget" render={({ history }) => (
                     <DailyBudgetPage
+                        location={this.props.location} />)}
+                />
+
+                <Route path="/daily_budget_edit" render={({ history }) => (
+                    <DailyBudgetEditPage
+                        dailyBudgetStore={this._dailyBudgetStore}
                         location={this.props.location} />)}
                 />
             </Switch>

--- a/src/ui/app/AppRoutes.test.js
+++ b/src/ui/app/AppRoutes.test.js
@@ -6,6 +6,7 @@ import AppRoutes from 'ui/app/AppRoutes';
 import BudgetSummaryPage from 'ui/summary/BudgetSummaryPage';
 import TransactionAmountPage from 'ui/transaction/TransactionAmountPage';
 import DailyBudgetPage from 'ui/settings/DailyBudgetPage';
+import DailyBudgetEditPage from 'ui/settings/DailyBudgetEditPage';
 import Budget from 'state/Budget';
 
 
@@ -20,6 +21,7 @@ describe('AppRoutes', () => {
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(1);
         expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
         expect(wrapper.find(DailyBudgetPage)).toHaveLength(0);
+        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(0);
     });
 
     it('renders TransactionAmountPage when the user navigates to /transactions', () => {
@@ -32,6 +34,7 @@ describe('AppRoutes', () => {
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);
         expect(wrapper.find(TransactionAmountPage)).toHaveLength(1);
         expect(wrapper.find(DailyBudgetPage)).toHaveLength(0);
+        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(0);
     });
 
     it('renders DailyBudgetPage when the user navigates to /daily_budget', () => {
@@ -44,6 +47,20 @@ describe('AppRoutes', () => {
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);
         expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
         expect(wrapper.find(DailyBudgetPage)).toHaveLength(1);
+        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(0);
+    });
+
+    it('renders DailyBudgetEditPage when the user navigates to /daily_budget_edit', () => {
+        const budget = Budget.create(10.00, []);
+        const wrapper = mount(
+            <MemoryRouter initialEntries={['/daily_budget_edit']}>
+                <AppRoutes appStore={_appStore()} budget={budget}/>
+            </MemoryRouter>
+        );
+        expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);
+        expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
+        expect(wrapper.find(DailyBudgetPage)).toHaveLength(0);
+        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(1);
     });
 });
 

--- a/src/ui/app/AppRoutes.test.js
+++ b/src/ui/app/AppRoutes.test.js
@@ -5,8 +5,7 @@ import { shallow, mount } from 'enzyme';
 import AppRoutes from 'ui/app/AppRoutes';
 import BudgetSummaryPage from 'ui/summary/BudgetSummaryPage';
 import TransactionAmountPage from 'ui/transaction/TransactionAmountPage';
-import DailyBudgetPage from 'ui/settings/DailyBudgetPage';
-import DailyBudgetEditPage from 'ui/settings/DailyBudgetEditPage';
+import SettingsRoutes from 'ui/settings/SettingsRoutes';
 import Budget from 'state/Budget';
 
 
@@ -15,52 +14,36 @@ describe('AppRoutes', () => {
         const budget = Budget.create(10.00, []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/']}>
-                <AppRoutes appStore={_appStore()} budget={budget} />
+                <AppRoutes appStore={_appStore()} budget={budget} location={{}} />
             </MemoryRouter>
         );
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(1);
         expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
-        expect(wrapper.find(DailyBudgetPage)).toHaveLength(0);
-        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(0);
+        expect(wrapper.find(SettingsRoutes)).toHaveLength(0);
     });
 
     it('renders TransactionAmountPage when the user navigates to /transactions', () => {
         const budget = Budget.create(10.00, []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/transactions']}>
-                <AppRoutes appStore={_appStore()} budget={budget}/>
+                <AppRoutes appStore={_appStore()} budget={budget} location={{}}/>
             </MemoryRouter>
         );
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);
         expect(wrapper.find(TransactionAmountPage)).toHaveLength(1);
-        expect(wrapper.find(DailyBudgetPage)).toHaveLength(0);
-        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(0);
+        expect(wrapper.find(SettingsRoutes)).toHaveLength(0);
     });
 
-    it('renders DailyBudgetPage when the user navigates to /daily_budget', () => {
+    it('renders SettingsRoutes when the user navigates to /settings', () => {
         const budget = Budget.create(10.00, []);
         const wrapper = mount(
-            <MemoryRouter initialEntries={['/daily_budget']}>
-                <AppRoutes appStore={_appStore()} budget={budget}/>
+            <MemoryRouter initialEntries={['/settings']}>
+                <AppRoutes appStore={_appStore()} budget={budget} location={{}}/>
             </MemoryRouter>
         );
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);
         expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
-        expect(wrapper.find(DailyBudgetPage)).toHaveLength(1);
-        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(0);
-    });
-
-    it('renders DailyBudgetEditPage when the user navigates to /daily_budget_edit', () => {
-        const budget = Budget.create(10.00, []);
-        const wrapper = mount(
-            <MemoryRouter initialEntries={['/daily_budget_edit']}>
-                <AppRoutes appStore={_appStore()} budget={budget}/>
-            </MemoryRouter>
-        );
-        expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);
-        expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
-        expect(wrapper.find(DailyBudgetPage)).toHaveLength(0);
-        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(1);
+        expect(wrapper.find(SettingsRoutes)).toHaveLength(1);
     });
 });
 

--- a/src/ui/app/AppRoutes.test.js
+++ b/src/ui/app/AppRoutes.test.js
@@ -55,6 +55,7 @@ function _appStore() {
             value: jest.fn(),
             setValue: jest.fn()
         })),
-        transactionStore: jest.fn(() => ({}))
+        transactionStore: jest.fn(() => ({})),
+        dailyBudgetStore: jest.fn(() => ({}))
     };
 }

--- a/src/ui/app/AppRoutes.test.js
+++ b/src/ui/app/AppRoutes.test.js
@@ -11,7 +11,7 @@ import Budget from 'state/Budget';
 
 describe('AppRoutes', () => {
     it('renders BudgetSummaryPage when the user navigates to /', () => {
-        const budget = Budget.create(10.00, []);
+        const budget = Budget.create([], []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/']}>
                 <AppRoutes appStore={_appStore()} budget={budget} location={{}} />

--- a/src/ui/app/AppRoutes.test.js
+++ b/src/ui/app/AppRoutes.test.js
@@ -51,10 +51,6 @@ function _appStore() {
     const user = jest.fn(() => ({}));
     return {
         user: user,
-        amountStore: jest.fn(() => ({
-            value: jest.fn(),
-            setValue: jest.fn()
-        })),
         transactionStore: jest.fn(() => ({})),
         dailyBudgetStore: jest.fn(() => ({}))
     };

--- a/src/ui/app/NavigationMenu.js
+++ b/src/ui/app/NavigationMenu.js
@@ -21,7 +21,7 @@ export default class NavigationMenu extends React.Component {
                     <NavbarToggler onClick={() => { this._onTogglerClicked() }} />
                     <Collapse isOpen={!this.state.collapsed} navbar>
                         <Nav navbar>
-                            {this._navItem('/daily_budget', 'Daily Budget Amount')}
+                            {this._navItem('/settings/daily_budget', 'Daily Budget Amount')}
                         </Nav>
                     </Collapse>
                 </Navbar>

--- a/src/ui/app/NavigationMenu.test.js
+++ b/src/ui/app/NavigationMenu.test.js
@@ -41,7 +41,7 @@ describe('NavigationMenu', () => {
     });
 
     it('marks the selected item as active when it matches the current location', () => {
-        const location = { pathname: '/daily_budget' };
+        const location = { pathname: '/settings/daily_budget' };
         const navigationMenu = shallow(<NavigationMenu location={location} />);
         
         navigationMenu.find(NavbarToggler).simulate('click');

--- a/src/ui/settings/DailyBudgetEditPage.js
+++ b/src/ui/settings/DailyBudgetEditPage.js
@@ -2,16 +2,32 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { observer } from 'mobx-react';
 
+import NumberPad from 'ui/numpad/NumberPad';
+
+import 'ui/app/AppPage.css';
+
+
+const DEFAULT_DAILY_BUDGET = 40;
 
 class DailyBudgetEditPage extends React.Component {
     render() {
         return(
             <div className="AppPage">
                 <p className="DailyBudgetEditPage-dailyBudget lead">
-                    Your daily budget is <strong>${this.props.dailyBudgetStore.value()}</strong>
+                    Your daily budget is <strong>${this._dailyBudget()}</strong>
                 </p>
+
+                <NumberPad valueStore={this.props.dailyBudgetStore} />
             </div>
         );
+    }
+
+    _dailyBudget() {
+        if(this.props.dailyBudgetStore.value() !== null) {
+            return Math.trunc(this.props.dailyBudgetStore.value());
+        } else {
+            return DEFAULT_DAILY_BUDGET;
+        }
     }
 }
 

--- a/src/ui/settings/DailyBudgetEditPage.js
+++ b/src/ui/settings/DailyBudgetEditPage.js
@@ -8,8 +8,6 @@ import { Button } from 'reactstrap';
 import 'ui/app/AppPage.css';
 
 
-const DEFAULT_DAILY_BUDGET = 40;
-
 class DailyBudgetEditPage extends React.Component {
     render() {
         return(
@@ -19,7 +17,7 @@ class DailyBudgetEditPage extends React.Component {
                         Your daily budget is <strong>${this._dailyBudget()}</strong>
                     </p>
 
-                    <NumberPad valueStore={this.props.dailyBudgetStore} />
+                    <NumberPad valueStore={this.props.budgetInputStore} />
                 </div>
 
                 <div>
@@ -43,24 +41,26 @@ class DailyBudgetEditPage extends React.Component {
         );
     }
 
-    _dailyBudget() {
-        if(this.props.dailyBudgetStore.value() !== null) {
-            return Math.trunc(this.props.dailyBudgetStore.value());
-        } else {
-            return DEFAULT_DAILY_BUDGET;
-        }
-    }
-
     _onClickSaveChange() {
+        this.props.dailyBudgetStore.addDailyBudget(this._dailyBudget(), new Date());
         this.props.history.push('/settings/daily_budget');
     }
 
     _onClickGoBack() {
         this.props.history.push('/settings/daily_budget');
     }
+
+    _dailyBudget() {
+        if(this.props.budgetInputStore.value() !== null) {
+            return Math.trunc(this.props.budgetInputStore.value());
+        } else {
+            return this.props.dailyBudgetStore.currentDailyBudget().amount();
+        }
+    }
 }
 
 DailyBudgetEditPage.propTypes = {
+    budgetInputStore: PropTypes.object.isRequired,
     dailyBudgetStore: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired
 };

--- a/src/ui/settings/DailyBudgetEditPage.js
+++ b/src/ui/settings/DailyBudgetEditPage.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { observer } from 'mobx-react';
+
+
+class DailyBudgetEditPage extends React.Component {
+    render() {
+        return(
+            <div className="AppPage">
+                <p className="DailyBudgetEditPage-dailyBudget lead">
+                    Your daily budget is <strong>${this.props.dailyBudgetStore.value()}</strong>
+                </p>
+            </div>
+        );
+    }
+}
+
+DailyBudgetEditPage.propTypes = {
+    dailyBudgetStore: PropTypes.object.isRequired
+};
+
+export default observer(DailyBudgetEditPage);

--- a/src/ui/settings/DailyBudgetEditPage.js
+++ b/src/ui/settings/DailyBudgetEditPage.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { observer } from 'mobx-react';
 
 import NumberPad from 'ui/numpad/NumberPad';
+import { Button } from 'reactstrap';
 
 import 'ui/app/AppPage.css';
 
@@ -13,11 +14,31 @@ class DailyBudgetEditPage extends React.Component {
     render() {
         return(
             <div className="AppPage">
-                <p className="DailyBudgetEditPage-dailyBudget lead">
-                    Your daily budget is <strong>${this._dailyBudget()}</strong>
-                </p>
+                <div>
+                    <p className="DailyBudgetEditPage-dailyBudget lead">
+                        Your daily budget is <strong>${this._dailyBudget()}</strong>
+                    </p>
 
-                <NumberPad valueStore={this.props.dailyBudgetStore} />
+                    <NumberPad valueStore={this.props.dailyBudgetStore} />
+                </div>
+
+                <div>
+                    <Button
+                        outline
+                        block
+                        className="DailyBudgetEditPage-saveChange"
+                        onClick={() => this._onClickSaveChange()}>
+                        Save Changes
+                    </Button>
+
+                    <Button
+                        outline
+                        block
+                        className="DailyBudgetEditPage-goBack"
+                        onClick={() => this._onClickGoBack()}>
+                        Go Back
+                    </Button>
+                </div>
             </div>
         );
     }
@@ -29,10 +50,19 @@ class DailyBudgetEditPage extends React.Component {
             return DEFAULT_DAILY_BUDGET;
         }
     }
+
+    _onClickSaveChange() {
+        this.props.history.push('/settings/daily_budget');
+    }
+
+    _onClickGoBack() {
+        this.props.history.push('/settings/daily_budget');
+    }
 }
 
 DailyBudgetEditPage.propTypes = {
-    dailyBudgetStore: PropTypes.object.isRequired
+    dailyBudgetStore: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired
 };
 
 export default observer(DailyBudgetEditPage);

--- a/src/ui/settings/DailyBudgetEditPage.test.js
+++ b/src/ui/settings/DailyBudgetEditPage.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import DailyBudgetEditPage from 'ui/settings/DailyBudgetEditPage';
+import ValueStore from 'state/ValueStore';
+
+
+describe('DailyBudgetEditPage', () => {
+    it('renders the current daily budget', () => {
+        const dailyBudgetStore = new ValueStore(20);
+        const dailyBudgetEditPage = shallow(<DailyBudgetEditPage
+            dailyBudgetStore={dailyBudgetStore}
+        />);
+
+        expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
+            .toBe('Your daily budget is $20');
+    });
+});

--- a/src/ui/settings/DailyBudgetEditPage.test.js
+++ b/src/ui/settings/DailyBudgetEditPage.test.js
@@ -2,17 +2,51 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import DailyBudgetEditPage from 'ui/settings/DailyBudgetEditPage';
+import NumberPad from 'ui/numpad/NumberPad';
 import ValueStore from 'state/ValueStore';
 
 
 describe('DailyBudgetEditPage', () => {
+    it('renders a default value of $40 if no value is supplied', () => {
+        const dailyBudgetStore = new ValueStore();
+        const dailyBudgetEditPage = shallow(
+            <DailyBudgetEditPage
+                dailyBudgetStore={dailyBudgetStore}
+        />);
+
+        expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
+            .toBe('Your daily budget is $40');
+    });
+
     it('renders the current daily budget', () => {
         const dailyBudgetStore = new ValueStore(20);
-        const dailyBudgetEditPage = shallow(<DailyBudgetEditPage
-            dailyBudgetStore={dailyBudgetStore}
+        const dailyBudgetEditPage = shallow(
+            <DailyBudgetEditPage
+                dailyBudgetStore={dailyBudgetStore}
         />);
 
         expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
             .toBe('Your daily budget is $20');
+    });
+
+    it('renders the current daily budget, truncated to a whole number', () => {
+        const dailyBudgetStore = new ValueStore(20.1234);
+        const dailyBudgetEditPage = shallow(
+            <DailyBudgetEditPage
+                dailyBudgetStore={dailyBudgetStore}
+        />);
+
+        expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
+            .toBe('Your daily budget is $20');
+    });
+
+    it('renders a NumberPad', () => {
+        const dailyBudgetStore = new ValueStore(20);
+        const dailyBudgetEditPage = shallow(
+            <DailyBudgetEditPage
+                dailyBudgetStore={dailyBudgetStore}
+        />);
+
+        expect(dailyBudgetEditPage.find(NumberPad)).toHaveLength(1);
     });
 });

--- a/src/ui/settings/DailyBudgetEditPage.test.js
+++ b/src/ui/settings/DailyBudgetEditPage.test.js
@@ -12,6 +12,7 @@ describe('DailyBudgetEditPage', () => {
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
+                history={{}}
         />);
 
         expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
@@ -23,6 +24,7 @@ describe('DailyBudgetEditPage', () => {
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
+                history={{}}
         />);
 
         expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
@@ -34,6 +36,7 @@ describe('DailyBudgetEditPage', () => {
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
+                history={{}}
         />);
 
         expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
@@ -45,8 +48,35 @@ describe('DailyBudgetEditPage', () => {
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
+                history={{}}
         />);
 
         expect(dailyBudgetEditPage.find(NumberPad)).toHaveLength(1);
+    });
+
+    it('navigates back to /settings/daily_budget when the save change button is clicked', () => {
+        const dailyBudgetStore = new ValueStore(20);
+        const history = { push: jest.fn() };
+        const dailyBudgetEditPage = shallow(
+            <DailyBudgetEditPage
+                dailyBudgetStore={dailyBudgetStore}
+                history={history}
+        />);
+
+        dailyBudgetEditPage.find('.DailyBudgetEditPage-saveChange').simulate('click');
+        expect(history.push).toHaveBeenCalledWith('/settings/daily_budget');
+    });
+
+    it('navigates back to /settings/daily_budget when the go back button is clicked', () => {
+        const dailyBudgetStore = new ValueStore(20);
+        const history = { push: jest.fn() };
+        const dailyBudgetEditPage = shallow(
+            <DailyBudgetEditPage
+                dailyBudgetStore={dailyBudgetStore}
+                history={history}
+        />);
+
+        dailyBudgetEditPage.find('.DailyBudgetEditPage-goBack').simulate('click');
+        expect(history.push).toHaveBeenCalledWith('/settings/daily_budget');
     });
 });

--- a/src/ui/settings/DailyBudgetEditPage.test.js
+++ b/src/ui/settings/DailyBudgetEditPage.test.js
@@ -13,7 +13,8 @@ describe('DailyBudgetEditPage', () => {
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
                 history={{}}
-        />);
+            />
+        );
 
         expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
             .toBe('Your daily budget is $40');
@@ -25,7 +26,8 @@ describe('DailyBudgetEditPage', () => {
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
                 history={{}}
-        />);
+            />
+        );
 
         expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
             .toBe('Your daily budget is $20');
@@ -37,7 +39,8 @@ describe('DailyBudgetEditPage', () => {
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
                 history={{}}
-        />);
+            />
+        );
 
         expect(dailyBudgetEditPage.find('.DailyBudgetEditPage-dailyBudget').text())
             .toBe('Your daily budget is $20');
@@ -49,7 +52,8 @@ describe('DailyBudgetEditPage', () => {
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
                 history={{}}
-        />);
+            />
+        );
 
         expect(dailyBudgetEditPage.find(NumberPad)).toHaveLength(1);
     });
@@ -61,7 +65,8 @@ describe('DailyBudgetEditPage', () => {
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
                 history={history}
-        />);
+            />
+        );
 
         dailyBudgetEditPage.find('.DailyBudgetEditPage-saveChange').simulate('click');
         expect(history.push).toHaveBeenCalledWith('/settings/daily_budget');
@@ -74,7 +79,8 @@ describe('DailyBudgetEditPage', () => {
             <DailyBudgetEditPage
                 dailyBudgetStore={dailyBudgetStore}
                 history={history}
-        />);
+            />
+        );
 
         dailyBudgetEditPage.find('.DailyBudgetEditPage-goBack').simulate('click');
         expect(history.push).toHaveBeenCalledWith('/settings/daily_budget');

--- a/src/ui/settings/DailyBudgetEditPage.test.js
+++ b/src/ui/settings/DailyBudgetEditPage.test.js
@@ -7,10 +7,13 @@ import ValueStore from 'state/ValueStore';
 
 
 describe('DailyBudgetEditPage', () => {
-    it('renders a default value of $40 if no value is supplied', () => {
-        const dailyBudgetStore = new ValueStore();
+    it('renders the current daily budget if no value is available in the budgetInputStore', () => {
+        const budgetInputStore = new ValueStore();
+        const currentDailyBudget = { amount: jest.fn(() => 40.00) };
+        const dailyBudgetStore = { currentDailyBudget: jest.fn(() => currentDailyBudget) };
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
+                budgetInputStore={budgetInputStore}
                 dailyBudgetStore={dailyBudgetStore}
                 history={{}}
             />
@@ -20,10 +23,12 @@ describe('DailyBudgetEditPage', () => {
             .toBe('Your daily budget is $40');
     });
 
-    it('renders the current daily budget', () => {
-        const dailyBudgetStore = new ValueStore(20);
+    it('renders the value in the input store if it is available', () => {
+        const budgetInputStore = new ValueStore(20);
+        const dailyBudgetStore = {};
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
+                budgetInputStore={budgetInputStore}
                 dailyBudgetStore={dailyBudgetStore}
                 history={{}}
             />
@@ -34,9 +39,11 @@ describe('DailyBudgetEditPage', () => {
     });
 
     it('renders the current daily budget, truncated to a whole number', () => {
-        const dailyBudgetStore = new ValueStore(20.1234);
+        const budgetInputStore = new ValueStore(20.1234);
+        const dailyBudgetStore = {};
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
+                budgetInputStore={budgetInputStore}
                 dailyBudgetStore={dailyBudgetStore}
                 history={{}}
             />
@@ -47,9 +54,11 @@ describe('DailyBudgetEditPage', () => {
     });
 
     it('renders a NumberPad', () => {
-        const dailyBudgetStore = new ValueStore(20);
+        const budgetInputStore = new ValueStore(20);
+        const dailyBudgetStore = {};
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
+                budgetInputStore={budgetInputStore}
                 dailyBudgetStore={dailyBudgetStore}
                 history={{}}
             />
@@ -58,25 +67,32 @@ describe('DailyBudgetEditPage', () => {
         expect(dailyBudgetEditPage.find(NumberPad)).toHaveLength(1);
     });
 
-    it('navigates back to /settings/daily_budget when the save change button is clicked', () => {
-        const dailyBudgetStore = new ValueStore(20);
+    it('saves the daily budget and returns to /settings/daily_budget when the save change button is clicked', () => {
+        const budgetInputStore = new ValueStore(20);
+        const dailyBudgetStore = { addDailyBudget: jest.fn() };
         const history = { push: jest.fn() };
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
+                budgetInputStore={budgetInputStore}
                 dailyBudgetStore={dailyBudgetStore}
                 history={history}
             />
         );
 
         dailyBudgetEditPage.find('.DailyBudgetEditPage-saveChange').simulate('click');
+        expect(dailyBudgetStore.addDailyBudget).toHaveBeenCalledTimes(1);
+        expect(dailyBudgetStore.addDailyBudget.mock.calls[0][0]).toBeCloseTo(20.00);
+        expect(dailyBudgetStore.addDailyBudget.mock.calls[0][1]).toBeInstanceOf(Date);
         expect(history.push).toHaveBeenCalledWith('/settings/daily_budget');
     });
 
     it('navigates back to /settings/daily_budget when the go back button is clicked', () => {
-        const dailyBudgetStore = new ValueStore(20);
+        const budgetInputStore = new ValueStore(20);
+        const dailyBudgetStore = { addDailyBudget: jest.fn() };
         const history = { push: jest.fn() };
         const dailyBudgetEditPage = shallow(
             <DailyBudgetEditPage
+                budgetInputStore={budgetInputStore}
                 dailyBudgetStore={dailyBudgetStore}
                 history={history}
             />

--- a/src/ui/settings/DailyBudgetPage.js
+++ b/src/ui/settings/DailyBudgetPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from 'reactstrap';
 
 import 'ui/app/AppPage.css';
 
@@ -7,10 +8,38 @@ export default class DailyBudgetPage extends React.Component {
     render() {
         return(
             <div className="AppPage">
-                <p className="DailyBudgetPage-dailyBudget lead">
-                    Your daily budget is <strong>$40</strong>
-                </p>
+                <div>
+                    <p className="DailyBudgetPage-dailyBudget lead">
+                        Your daily budget is <strong>$40</strong>
+                    </p>
+                </div>
+
+                <div>
+                    <Button
+                        outline
+                        block
+                        className="DailyBudgetPage-edit"
+                        onClick={() => this._onClickEdit()}>
+                        Edit
+                    </Button>
+
+                    <Button
+                        outline
+                        block
+                        className="DailyBudgetPage-budgetSummary"
+                        onClick={() => this._onClickBudgetSummary()}>
+                        Budget Summary
+                    </Button>
+                </div>
             </div>
         );
+    }
+
+    _onClickEdit() {
+        this.props.history.push('/settings/daily_budget/edit');
+    }
+
+    _onClickBudgetSummary() {
+        this.props.history.push('/');
     }
 }

--- a/src/ui/settings/DailyBudgetPage.js
+++ b/src/ui/settings/DailyBudgetPage.js
@@ -24,14 +24,6 @@ class DailyBudgetPage extends React.Component {
                         onClick={() => this._onClickEdit()}>
                         Edit
                     </Button>
-
-                    <Button
-                        outline
-                        block
-                        className="DailyBudgetPage-budgetSummary"
-                        onClick={() => this._onClickBudgetSummary()}>
-                        Budget Summary
-                    </Button>
                 </div>
             </div>
         );
@@ -39,10 +31,6 @@ class DailyBudgetPage extends React.Component {
 
     _onClickEdit() {
         this.props.history.push('/settings/daily_budget/edit');
-    }
-
-    _onClickBudgetSummary() {
-        this.props.history.push('/');
     }
 }
 

--- a/src/ui/settings/DailyBudgetPage.js
+++ b/src/ui/settings/DailyBudgetPage.js
@@ -1,16 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { observer } from 'mobx-react';
 import { Button } from 'reactstrap';
 
 import 'ui/app/AppPage.css';
 
 
-export default class DailyBudgetPage extends React.Component {
+class DailyBudgetPage extends React.Component {
     render() {
         return(
             <div className="AppPage">
                 <div>
                     <p className="DailyBudgetPage-dailyBudget lead">
-                        Your daily budget is <strong>$40</strong>
+                        Your daily budget is <strong>${this.props.currentDailyBudget}</strong>
                     </p>
                 </div>
 
@@ -43,3 +45,10 @@ export default class DailyBudgetPage extends React.Component {
         this.props.history.push('/');
     }
 }
+
+DailyBudgetPage.propTypes = {
+    currentDailyBudget: PropTypes.number.isRequired,
+    history: PropTypes.object.isRequired
+};
+
+export default observer(DailyBudgetPage);

--- a/src/ui/settings/DailyBudgetPage.test.js
+++ b/src/ui/settings/DailyBudgetPage.test.js
@@ -29,17 +29,4 @@ describe('DailyBudgetPage', () => {
         dailyBudgetEditPage.find('.DailyBudgetPage-edit').simulate('click');
         expect(history.push).toHaveBeenCalledWith('/settings/daily_budget/edit');
     });
-
-    it('navigates back to / when the budget summary button is clicked', () => {
-        const history = { push: jest.fn() };
-        const dailyBudgetEditPage = shallow(
-            <DailyBudgetPage
-                currentDailyBudget={30.00}
-                history={history}
-            />
-        );
-
-        dailyBudgetEditPage.find('.DailyBudgetPage-budgetSummary').simulate('click');
-        expect(history.push).toHaveBeenCalledWith('/');
-    });
 });

--- a/src/ui/settings/DailyBudgetPage.test.js
+++ b/src/ui/settings/DailyBudgetPage.test.js
@@ -10,4 +10,28 @@ describe('DailyBudgetPage', () => {
         expect(dailyBudgetPage.find('.DailyBudgetPage-dailyBudget').text())
             .toBe('Your daily budget is $40');
     });
+
+    it('navigates to /settings/daily_budget/edit when the edit button is clicked', () => {
+        const history = { push: jest.fn() };
+        const dailyBudgetEditPage = shallow(
+            <DailyBudgetPage
+                history={history}
+            />
+        );
+
+        dailyBudgetEditPage.find('.DailyBudgetPage-edit').simulate('click');
+        expect(history.push).toHaveBeenCalledWith('/settings/daily_budget/edit');
+    });
+
+    it('navigates back to / when the budget summary button is clicked', () => {
+        const history = { push: jest.fn() };
+        const dailyBudgetEditPage = shallow(
+            <DailyBudgetPage
+                history={history}
+            />
+        );
+
+        dailyBudgetEditPage.find('.DailyBudgetPage-budgetSummary').simulate('click');
+        expect(history.push).toHaveBeenCalledWith('/');
+    });
 });

--- a/src/ui/settings/DailyBudgetPage.test.js
+++ b/src/ui/settings/DailyBudgetPage.test.js
@@ -5,16 +5,23 @@ import DailyBudgetPage from 'ui/settings/DailyBudgetPage';
 
 
 describe('DailyBudgetPage', () => {
-    it('renders $40.00 as the current daily budget', () => {
-        const dailyBudgetPage = shallow(<DailyBudgetPage />);
+    it('renders the current daily budget', () => {
+        const dailyBudgetPage = shallow(
+            <DailyBudgetPage
+                currentDailyBudget={30.00}
+                history={history}
+            />
+        );
+        
         expect(dailyBudgetPage.find('.DailyBudgetPage-dailyBudget').text())
-            .toBe('Your daily budget is $40');
+            .toBe('Your daily budget is $30');
     });
 
     it('navigates to /settings/daily_budget/edit when the edit button is clicked', () => {
         const history = { push: jest.fn() };
         const dailyBudgetEditPage = shallow(
             <DailyBudgetPage
+                currentDailyBudget={30.00}
                 history={history}
             />
         );
@@ -27,6 +34,7 @@ describe('DailyBudgetPage', () => {
         const history = { push: jest.fn() };
         const dailyBudgetEditPage = shallow(
             <DailyBudgetPage
+                currentDailyBudget={30.00}
                 history={history}
             />
         );

--- a/src/ui/settings/SettingsRoutes.js
+++ b/src/ui/settings/SettingsRoutes.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { observer } from 'mobx-react';
+import { Switch, Route } from 'react-router-dom';
+
+import DailyBudgetPage from 'ui/settings/DailyBudgetPage';
+import DailyBudgetEditPage from 'ui/settings/DailyBudgetEditPage';
+import ValueStore from 'state/ValueStore';
+
+
+class SettingsRoutes extends React.Component {
+    constructor(props) {
+        super(props);
+        this._dailyBudgetStore = new ValueStore();
+    }
+
+    render() {
+        return(
+            <Switch>
+                <Route exact path="/settings/daily_budget" render={({ history }) => (
+                    <DailyBudgetPage />
+                )} />
+
+                <Route path="/settings/daily_budget/edit" render={({ history }) => (
+                    <DailyBudgetEditPage dailyBudgetStore={this._dailyBudgetStore}/>
+                )} />
+            </Switch>
+        );
+    }
+}
+
+SettingsRoutes.propTypes = {
+};
+
+export default observer(SettingsRoutes);

--- a/src/ui/settings/SettingsRoutes.js
+++ b/src/ui/settings/SettingsRoutes.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { observer } from 'mobx-react';
 import { Switch, Route } from 'react-router-dom';
 
@@ -10,7 +11,7 @@ import ValueStore from 'state/ValueStore';
 class SettingsRoutes extends React.Component {
     constructor(props) {
         super(props);
-        this._dailyBudgetStore = new ValueStore();
+        this._budgetInputStore = new ValueStore();
     }
 
     render() {
@@ -18,19 +19,29 @@ class SettingsRoutes extends React.Component {
             <Switch>
                 <Route exact path="/settings/daily_budget" render={({ history }) => (
                     <DailyBudgetPage
+                        currentDailyBudget={this._currentDailyBudget()}
                         history={history} 
                     />
                 )} />
 
                 <Route path="/settings/daily_budget/edit" render={({ history }) => (
                     <DailyBudgetEditPage
-                        dailyBudgetStore={this._dailyBudgetStore}
+                        budgetInputStore={this._budgetInputStore}
+                        dailyBudgetStore={this.props.dailyBudgetStore}
                         history={history}
                     />
                 )} />
             </Switch>
         );
     }
+
+    _currentDailyBudget() {
+        return this.props.dailyBudgetStore.currentDailyBudget().amount();
+    }
 }
+
+SettingsRoutes.propTypes = {
+    dailyBudgetStore: PropTypes.object.isRequired
+};
 
 export default observer(SettingsRoutes);

--- a/src/ui/settings/SettingsRoutes.js
+++ b/src/ui/settings/SettingsRoutes.js
@@ -18,7 +18,9 @@ class SettingsRoutes extends React.Component {
         return(
             <Switch>
                 <Route exact path="/settings/daily_budget" render={({ history }) => (
-                    <DailyBudgetPage />
+                    <DailyBudgetPage
+                        history={history} 
+                    />
                 )} />
 
                 <Route path="/settings/daily_budget/edit" render={({ history }) => (

--- a/src/ui/settings/SettingsRoutes.js
+++ b/src/ui/settings/SettingsRoutes.js
@@ -22,7 +22,10 @@ class SettingsRoutes extends React.Component {
                 )} />
 
                 <Route path="/settings/daily_budget/edit" render={({ history }) => (
-                    <DailyBudgetEditPage dailyBudgetStore={this._dailyBudgetStore}/>
+                    <DailyBudgetEditPage
+                        dailyBudgetStore={this._dailyBudgetStore}
+                        history={history}
+                    />
                 )} />
             </Switch>
         );

--- a/src/ui/settings/SettingsRoutes.js
+++ b/src/ui/settings/SettingsRoutes.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { observer } from 'mobx-react';
 import { Switch, Route } from 'react-router-dom';
 
@@ -33,8 +32,5 @@ class SettingsRoutes extends React.Component {
         );
     }
 }
-
-SettingsRoutes.propTypes = {
-};
 
 export default observer(SettingsRoutes);

--- a/src/ui/settings/SettingsRoutes.test.js
+++ b/src/ui/settings/SettingsRoutes.test.js
@@ -9,9 +9,12 @@ import DailyBudgetEditPage from 'ui/settings/DailyBudgetEditPage';
 
 describe('SettingsRoutes', () => {
     it('renders DailyBudgetPage when the user navigates to /settings/daily_budget', () => {
+        const currentDailyBudget = { amount: jest.fn(() => 40.00) };
+        const dailyBudgetStore = { currentDailyBudget: jest.fn(() => currentDailyBudget) };
+
         const wrapper = mount(
             <MemoryRouter initialEntries={['/settings/daily_budget']}>
-                <SettingsRoutes />
+                <SettingsRoutes dailyBudgetStore={dailyBudgetStore}/>
             </MemoryRouter>
         );
         expect(wrapper.find(DailyBudgetPage)).toHaveLength(1);
@@ -19,9 +22,12 @@ describe('SettingsRoutes', () => {
     });
 
     it('renders DailyBudgetEditPage when the user navigates to /settings/daily_budget/edit', () => {
+        const currentDailyBudget = { amount: jest.fn(() => 40.00) };
+        const dailyBudgetStore = { currentDailyBudget: jest.fn(() => currentDailyBudget) };
+
         const wrapper = mount(
             <MemoryRouter initialEntries={['/settings/daily_budget/edit']}>
-                <SettingsRoutes />
+                <SettingsRoutes dailyBudgetStore={dailyBudgetStore} />
             </MemoryRouter>
         );
         expect(wrapper.find(DailyBudgetPage)).toHaveLength(0);

--- a/src/ui/settings/SettingsRoutes.test.js
+++ b/src/ui/settings/SettingsRoutes.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { mount } from 'enzyme';
+
+import SettingsRoutes from 'ui/settings/SettingsRoutes';
+import DailyBudgetPage from 'ui/settings/DailyBudgetPage';
+import DailyBudgetEditPage from 'ui/settings/DailyBudgetEditPage';
+
+
+describe('SettingsRoutes', () => {
+    it('renders DailyBudgetPage when the user navigates to /settings/daily_budget', () => {
+        const wrapper = mount(
+            <MemoryRouter initialEntries={['/settings/daily_budget']}>
+                <SettingsRoutes />
+            </MemoryRouter>
+        );
+        expect(wrapper.find(DailyBudgetPage)).toHaveLength(1);
+        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(0);
+    });
+
+    it('renders DailyBudgetEditPage when the user navigates to /settings/daily_budget/edit', () => {
+        const wrapper = mount(
+            <MemoryRouter initialEntries={['/settings/daily_budget/edit']}>
+                <SettingsRoutes />
+            </MemoryRouter>
+        );
+        expect(wrapper.find(DailyBudgetPage)).toHaveLength(0);
+        expect(wrapper.find(DailyBudgetEditPage)).toHaveLength(1);
+    });
+});

--- a/src/ui/summary/BudgetSummaryPage.test.js
+++ b/src/ui/summary/BudgetSummaryPage.test.js
@@ -3,13 +3,15 @@ import { shallow } from 'enzyme';
 
 import BudgetSummary from 'ui/summary/BudgetSummaryPage';
 import Budget from 'state/Budget';
+import DailyBudget from 'state/DailyBudget';
 import { Button } from 'reactstrap';
 
 
 describe('BudgetSummary', () => {
     it('renders the current user\'s display name and current budget', () => {
         const user = { displayName: 'Fred Rogers' };
-        const budget = new Budget(new Date(2018, 2, 15), 10.00, []);
+        const dailyBudget = new DailyBudget('id1', 50.00, new Date('2018-02-12T11:00:00.000Z'));
+        const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [dailyBudget], []);
         const history = { push: jest.fn() };
         const budgetSummary = shallow(<BudgetSummary user={user} budget={budget} history={history}/>);
 
@@ -19,7 +21,7 @@ describe('BudgetSummary', () => {
 
     it('renders the add transaction button', () => {
         const user = { displayName: 'Fred Rogers' };
-        const budget = new Budget(new Date(2018, 2, 15), 10.00, []);
+        const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [], []);
         const history = { push: jest.fn() };
         const budgetSummary = shallow(<BudgetSummary user={user} budget={budget} history={history}/>);
 
@@ -28,7 +30,7 @@ describe('BudgetSummary', () => {
 
     it('navigates to /transactions when the add transaction button is clicked', () => {
         const user = { displayName: 'Fred Rogers' };
-        const budget = new Budget(new Date(2018, 2, 15), 10.00, []);
+        const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [], []);
         const history = { push: jest.fn() };
         const budgetSummary = shallow(<BudgetSummary user={user} budget={budget} history={history}/>);
 


### PR DESCRIPTION
As a user, I would like to edit my daily budget amount, so my budget reflect my personal monthly income. 

Acceptance Criteria:
* There is a way to edit the amount on the "Daily Budget Amount" page.  (I am thinking the same design scheme as the button that says "Add Transaction" But up for other ideas)
* The daily budget amount doesn't adjust anything in the past, only transactions in the future. 
* After editing, the new amount shows on the "Daily Budget Amount" page