### PR TITLE
View transactions page

### DIFF
--- a/src/ui/app/AppRoutes.js
+++ b/src/ui/app/AppRoutes.js
@@ -4,18 +4,11 @@ import PropTypes from 'prop-types';
 import { Switch, Route } from 'react-router-dom';
 
 import BudgetSummaryPage from 'ui/summary/BudgetSummaryPage';
-import TransactionAmountPage from 'ui/transaction/TransactionAmountPage';
+import TransactionRoutes from 'ui/transaction/TransactionRoutes';
 import SettingsRoutes from 'ui/settings/SettingsRoutes';
-import ValueStore from 'state/ValueStore';
 
 
 class AppRoutes extends React.Component {
-    constructor(props) {
-        super(props);
-        this._amountStore = new ValueStore();
-        this._categoryStore = new ValueStore();
-    }
-
     render() {
         return(
             <Switch>
@@ -29,9 +22,7 @@ class AppRoutes extends React.Component {
                 />
                 
                 <Route path="/transactions" render={({ history }) => (
-                    <TransactionAmountPage
-                        amountStore={this._amountStore}
-                        categoryStore={this._categoryStore}
+                    <TransactionRoutes
                         transactionStore={this.props.appStore.transactionStore()}
                         history={history}
                         location={this.props.location}

--- a/src/ui/app/AppRoutes.test.js
+++ b/src/ui/app/AppRoutes.test.js
@@ -4,7 +4,7 @@ import { shallow, mount } from 'enzyme';
 
 import AppRoutes from 'ui/app/AppRoutes';
 import BudgetSummaryPage from 'ui/summary/BudgetSummaryPage';
-import TransactionAmountPage from 'ui/transaction/TransactionAmountPage';
+import TransactionRoutes from 'ui/transaction/TransactionRoutes';
 import SettingsRoutes from 'ui/settings/SettingsRoutes';
 import Budget from 'state/Budget';
 
@@ -18,7 +18,7 @@ describe('AppRoutes', () => {
             </MemoryRouter>
         );
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(1);
-        expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
+        expect(wrapper.find(TransactionRoutes)).toHaveLength(0);
         expect(wrapper.find(SettingsRoutes)).toHaveLength(0);
     });
 
@@ -30,7 +30,7 @@ describe('AppRoutes', () => {
             </MemoryRouter>
         );
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);
-        expect(wrapper.find(TransactionAmountPage)).toHaveLength(1);
+        expect(wrapper.find(TransactionRoutes)).toHaveLength(1);
         expect(wrapper.find(SettingsRoutes)).toHaveLength(0);
     });
 
@@ -42,7 +42,7 @@ describe('AppRoutes', () => {
             </MemoryRouter>
         );
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);
-        expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
+        expect(wrapper.find(TransactionRoutes)).toHaveLength(0);
         expect(wrapper.find(SettingsRoutes)).toHaveLength(1);
     });
 });

--- a/src/ui/summary/BudgetSummaryPage.js
+++ b/src/ui/summary/BudgetSummaryPage.js
@@ -15,13 +15,23 @@ class BudgetSummaryPage extends React.Component {
                     Hello {this._name()},<br />you have <strong>${this._amount()}</strong> to spend today.
                 </p>
 
-                <Button
-                    className='BudgetSummaryPage-addTransaction'
-                    outline
-                    block
-                    onClick={() => this._onAddTransactionClicked()}>
-                    Add Transaction
-                </Button>
+                <div>
+                    <Button
+                        className='BudgetSummaryPage-addTransaction'
+                        outline
+                        block
+                        onClick={() => this._onAddTransactionClicked()}>
+                        Add Transaction
+                    </Button>
+
+                    <Button
+                        className='BudgetSummaryPage-viewPastTransactions'
+                        outline
+                        block
+                        onClick={() => this._onViewPastTransactionsClicked()}>
+                        View Past Transactions
+                    </Button>
+                </div>
             </section>
         );
     }
@@ -35,6 +45,10 @@ class BudgetSummaryPage extends React.Component {
     }
 
     _onAddTransactionClicked() {
+        this.props.history.push('/transactions/new');
+    }
+
+    _onViewPastTransactionsClicked() {
         this.props.history.push('/transactions');
     }
 }

--- a/src/ui/summary/BudgetSummaryPage.test.js
+++ b/src/ui/summary/BudgetSummaryPage.test.js
@@ -19,22 +19,23 @@ describe('BudgetSummary', () => {
             .toBe('Hello Fred Rogers,you have $150.00 to spend today.');
     });
 
-    it('renders the add transaction button', () => {
-        const user = { displayName: 'Fred Rogers' };
-        const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [], []);
-        const history = { push: jest.fn() };
-        const budgetSummary = shallow(<BudgetSummary user={user} budget={budget} history={history}/>);
-
-        expect(budgetSummary.find('.BudgetSummaryPage-addTransaction')).toHaveLength(1);
-    });
-
-    it('navigates to /transactions when the add transaction button is clicked', () => {
+    it('navigates to /transactions/new when the add transaction button is clicked', () => {
         const user = { displayName: 'Fred Rogers' };
         const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [], []);
         const history = { push: jest.fn() };
         const budgetSummary = shallow(<BudgetSummary user={user} budget={budget} history={history}/>);
 
         budgetSummary.find('.BudgetSummaryPage-addTransaction').simulate('click');
+        expect(history.push).toHaveBeenCalledWith('/transactions/new');
+    });
+
+    it('navigates to /transactions when the view past transactions button is clicked', () => {
+        const user = { displayName: 'Fred Rogers' };
+        const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [], []);
+        const history = { push: jest.fn() };
+        const budgetSummary = shallow(<BudgetSummary user={user} budget={budget} history={history}/>);
+
+        budgetSummary.find('.BudgetSummaryPage-viewPastTransactions').simulate('click');
         expect(history.push).toHaveBeenCalledWith('/transactions');
     });
 });

--- a/src/ui/transaction/TransactionRoutes.js
+++ b/src/ui/transaction/TransactionRoutes.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { observer } from 'mobx-react';
+import PropTypes from 'prop-types';
+import { Switch, Route } from 'react-router-dom';
+
+import TransactionsIndexPage from 'ui/transaction/TransactionsIndexPage';
+import TransactionAmountPage from 'ui/transaction/TransactionAmountPage';
+import ValueStore from 'state/ValueStore';
+
+
+class TransactionRoutesPage extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this._amountStore = new ValueStore();
+        this._categoryStore = new ValueStore();
+    }
+
+    render() {
+        return(
+            <Switch>
+                <Route exact path="/transactions" render={({ history }) => (
+                    <TransactionsIndexPage
+                        transactionStore={this.props.transactionStore}
+                        history={history} 
+                    />
+                )} />
+
+                <Route path="/transactions/new" render={({ history }) => (
+                    <TransactionAmountPage
+                        amountStore={this._amountStore}
+                        categoryStore={this._categoryStore}
+                        transactionStore={this.props.transactionStore}
+                        history={history} 
+                    />
+                )} />
+            </Switch>
+        );
+    }
+}
+
+TransactionRoutesPage.propTypes = {
+    transactionStore: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired
+};
+
+export default observer(TransactionRoutesPage);

--- a/src/ui/transaction/TransactionRoutes.test.js
+++ b/src/ui/transaction/TransactionRoutes.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { shallow, mount } from 'enzyme';
+
+import TransactionRoutes from 'ui/transaction/TransactionRoutes';
+import TransactionAmountPage from 'ui/transaction/TransactionAmountPage';
+import TransactionsIndexPage from 'ui/transaction/TransactionsIndexPage';
+
+
+describe('TransactionRoutes', () => {
+    it('renders TransactionsIndexPage when the user navigates to /transactions', () => {
+        const wrapper = mount(
+            <MemoryRouter initialEntries={['/transactions']}>
+                <TransactionRoutes transactionStore={{}} history={{}} location={{}}/>
+            </MemoryRouter>
+        );
+        expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
+        expect(wrapper.find(TransactionsIndexPage)).toHaveLength(1);
+    });
+
+    it('renders TransactionAmountPage when the user navigates to /transactions/new', () => {
+        const wrapper = mount(
+            <MemoryRouter initialEntries={['/transactions/new']}>
+                <TransactionRoutes transactionStore={{}} history={{}} location={{}}/>
+            </MemoryRouter>
+        );
+        expect(wrapper.find(TransactionAmountPage)).toHaveLength(1);
+        expect(wrapper.find(TransactionsIndexPage)).toHaveLength(0);
+    });
+});

--- a/src/ui/transaction/TransactionsIndexPage.js
+++ b/src/ui/transaction/TransactionsIndexPage.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { observer } from 'mobx-react';
+import PropTypes from 'prop-types';
+
+
+class TransactionsIndexPage extends React.Component {
+    render() {
+        return <p>I like turtles.</p>
+    }
+}
+
+TransactionsIndexPage.propTypes = {
+    transactionStore: PropTypes.object.isRequired
+};
+
+export default observer(TransactionsIndexPage);

--- a/src/ui/transaction/TransactionsIndexPage.test.js
+++ b/src/ui/transaction/TransactionsIndexPage.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TransactionsIndexPage from 'ui/transaction/TransactionsIndexPage';
+
+
+describe('TransactionsIndexPage', () => {
+    it('renders I like turtles', () => {
+        const transactionsIndexPage = shallow(<TransactionsIndexPage transactionStore={{}} />);
+        expect(transactionsIndexPage.find('p').text()).toBe('I like turtles.');
+    });
+});


### PR DESCRIPTION
As a user, I want to see where I can view my past transactions, so that I know where to go when I am viewing my spending for the month. 

Acceptance Criteria:
* There exists a button under "add transaction" that says View Past Transactions
* Clicking on the button takes the user to a page that does nothing. 
* Clicking the home screen takes the use to the main page. 