### PR TITLE
Add income category

### DIFF
--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -17,7 +17,8 @@ type Category extends String {
             this === 'General' || 
             this === 'Outing' ||
             this === 'Car' ||
-            this === 'Groceries';
+            this === 'Groceries' ||
+            this === 'Income';
     }
 }
 

--- a/src/state/Budget.js
+++ b/src/state/Budget.js
@@ -1,4 +1,5 @@
 import BudgetAccumulator from 'state/BudgetAccumulator';
+import Transaction from 'state/Transaction';
 
 
 export default class Budget {
@@ -21,7 +22,7 @@ export default class Budget {
     }
 
     _amountSpent() {
-        return this._transactionsThisMonth().reduce((sum, t) => sum + t.amount(), 0.00);
+        return Transaction.totalExpenses(this._transactionsThisMonth());
     }
 
     _transactionsThisMonth() {

--- a/src/state/Budget.test.js
+++ b/src/state/Budget.test.js
@@ -25,19 +25,20 @@ describe('create', () => {
 });
 
 describe('current', () => {
-    it('returns the amount accrued minus the amount spent', () => {
+    it('returns the amount accrued or received as income minus the amount spent', () => {
         const today = new Date('2018-04-02T11:00:00.000Z');;
         
         const dailyBudgets = [
             new DailyBudget('id1', 40.00, new Date('2018-04-01T11:00:00.000Z'))
         ];
         const transactions = [
-            new Transaction('id1', 10.00, new Date('2018-04-01T11:00:00.000Z'), 'Disneyland'),
-            new Transaction('id2', 15.00, new Date('2018-04-02T11:00:00.000Z'), 'Knotts')
+            new Transaction('id1', 10.00, new Date('2018-04-01T11:00:00.000Z'), 'General'),
+            new Transaction('id2', 15.00, new Date('2018-04-02T11:00:00.000Z'), 'Car'),
+            new Transaction('id2', 4.00, new Date('2018-04-02T11:00:00.000Z'), 'Income')
         ];
 
         const budget = new Budget(today, dailyBudgets, transactions);
-        expect(budget.current()).toBeCloseTo(15.00);
+        expect(budget.current()).toBeCloseTo(19.00);
     });
 
     it('ignores transactions from a previous month', () => {

--- a/src/state/Transaction.js
+++ b/src/state/Transaction.js
@@ -1,4 +1,17 @@
 export default class Transaction {
+    static EXPENSE = 1;
+    static INCOME = 2;
+
+    static totalExpenses(transactions) {
+        return transactions.reduce(
+            (sum, t) => (
+                t.type() === Transaction.EXPENSE ?
+                    sum + t.amount() :
+                    sum - t.amount()),
+                0.00
+        );
+    }
+
     constructor(id, amount, occurredAt, category) {
         this._id = id;
         this._amount = amount;
@@ -8,6 +21,14 @@ export default class Transaction {
 
     id() {
         return this._id;
+    }
+
+    type() {
+        if(this._category === 'Income') {
+            return Transaction.INCOME;
+        } else {
+            return Transaction.EXPENSE;
+        }
     }
 
     amount() {

--- a/src/state/Transaction.test.js
+++ b/src/state/Transaction.test.js
@@ -1,10 +1,56 @@
 import Transaction from 'state/Transaction';
 
 
+describe('totalExpenses', () => {
+    it('returns the sum of expenses', () => {
+        const expense1 = new Transaction('id', 12.00, new Date(), 'General');
+        const expense2 = new Transaction('id', 3.00, new Date(), 'General');
+        expect(Transaction.totalExpenses([expense1, expense2])).toBeCloseTo(15.00);
+    });
+
+    it('subtracts income from the expenses', () => {
+        const expense = new Transaction('id', 12.00, new Date(), 'General');
+        const income = new Transaction('id', 3.00, new Date(), 'Income');
+        expect(Transaction.totalExpenses([expense, income])).toBeCloseTo(9.00);
+    });
+});
+
 describe('id', () => {
     it('returns the transaction id', () => {
         const transaction = new Transaction('id', 12.3, new Date(), 'Disneyland');
         expect(transaction.id()).toBe('id');
+    });
+});
+
+describe('type', () => {
+    it('returns the income type for a transaction with "Income" category', () => {
+        const transaction = new Transaction('id', 12.3, new Date(), 'Income');
+        expect(transaction.type()).toBe(Transaction.INCOME);
+    });
+
+    it('returns the expense type for a transaction with "General" category', () => {
+        const transaction = new Transaction('id', 12.3, new Date(), 'General');
+        expect(transaction.type()).toBe(Transaction.EXPENSE);
+    });
+
+    it('returns the expense type for a transaction with "Outing" category', () => {
+        const transaction = new Transaction('id', 12.3, new Date(), 'Outing');
+        expect(transaction.type()).toBe(Transaction.EXPENSE);
+    });
+
+    it('returns the expense type for a transaction with "Car" category', () => {
+        const transaction = new Transaction('id', 12.3, new Date(), 'Car');
+        expect(transaction.type()).toBe(Transaction.EXPENSE);
+    });
+
+    it('returns the expense type for a transaction with "Groceries" category', () => {
+        const transaction = new Transaction('id', 12.3, new Date(), 'Groceries');
+        expect(transaction.type()).toBe(Transaction.EXPENSE);
+    });
+
+    it('returns the expense type for a transaction with an unknown category', () => {
+        const transaction = new Transaction('id', 12.3, new Date(), 'Disneyland');
+        expect(transaction.type()).toBe(Transaction.EXPENSE);
     });
 });
 

--- a/src/state/TransactionValidations.test.js
+++ b/src/state/TransactionValidations.test.js
@@ -183,4 +183,15 @@ describe('category', () => {
         });
         expect(allowed).toBeTruthy();
     });
+
+    it('allows saving a transaction with the Income category', () => {
+        const database = targaryen.database(rules, {}).as({ uid: 'userId' });
+        const { allowed } = database.write('/accounts/userId/transactions/abcd', {
+            id: 'abcd',
+            amount: 15.00,
+            occurredAt: '2018-04-17T03:50:53.161Z',
+            category: 'Income'
+        });
+        expect(allowed).toBeTruthy();
+    });
 });

--- a/src/ui/app/AppTheme.css
+++ b/src/ui/app/AppTheme.css
@@ -2,4 +2,7 @@
     --lightColor: white;
     --darkColor: #222;
     --selectedColor: dodgerblue;
+
+    --gainColor: mediumseagreen;
+    --lossColor: crimson;
 }

--- a/src/ui/transaction/CategoryIconMapper.js
+++ b/src/ui/transaction/CategoryIconMapper.js
@@ -5,6 +5,7 @@ export default class CategoryIconMapper {
             case 'Outing' : return 'coffee';
             case 'Car' : return 'car';
             case 'Groceries' : return 'shopping-cart';
+            case 'Income' : return 'money';
             default: return 'question';
         }
     }

--- a/src/ui/transaction/CategoryIconMapper.test.js
+++ b/src/ui/transaction/CategoryIconMapper.test.js
@@ -18,6 +18,10 @@ describe('toIcon', () => {
         expect(CategoryIconMapper.toIcon('Groceries')).toBe('shopping-cart');
     });
 
+    it('returns the shopping-cart icon for the Income category', () => {
+        expect(CategoryIconMapper.toIcon('Income')).toBe('money');
+    });
+
     it('returns the question icon for an unknown category', () => {
         expect(CategoryIconMapper.toIcon('Barf')).toBe('question');
     });

--- a/src/ui/transaction/CategorySelector.js
+++ b/src/ui/transaction/CategorySelector.js
@@ -21,6 +21,7 @@ class CategorySelector extends React.Component {
                 {this._category('Outing')}
                 {this._category('Car')}
                 {this._category('Groceries')}
+                {this._category('Income')}
             </div>
         );
     }

--- a/src/ui/transaction/CategorySelector.test.js
+++ b/src/ui/transaction/CategorySelector.test.js
@@ -26,6 +26,11 @@ describe('CategorySelector', () => {
         expect(categorySelector.find('.Category-groceries')).toHaveLength(1);
     });
 
+    it('renders an "Income" category', () => {
+        const categorySelector = shallow(<CategorySelector categoryStore={new ValueStore()} />);
+        expect(categorySelector.find('.Category-income')).toHaveLength(1);
+    });
+
     it('selects the "General" category by default', () => {
         const valueStore = new ValueStore();
         const categorySelector = shallow(<CategorySelector categoryStore={valueStore} />);
@@ -76,6 +81,17 @@ describe('CategorySelector', () => {
         categorySelector.find('.Category-groceries').simulate('click');
         expect(categorySelector
             .find('.Category-groceries')
+            .hasClass('Category--selected')
+        ).toBeTruthy();
+    });
+
+    it('selects the "Income" category when clicked', () => {
+        const valueStore = new ValueStore();
+        const categorySelector = shallow(<CategorySelector categoryStore={valueStore} />);
+        
+        categorySelector.find('.Category-income').simulate('click');
+        expect(categorySelector
+            .find('.Category-income')
             .hasClass('Category--selected')
         ).toBeTruthy();
     });

--- a/src/ui/transaction/TransactionsIndexPage.css
+++ b/src/ui/transaction/TransactionsIndexPage.css
@@ -23,6 +23,14 @@
     font-weight: bold;
 }
 
+.TransactionsIndexPage-total--gain {
+    color: var(--gainColor);
+}
+
+.TransactionsIndexPage-total--loss {
+    color: var(--lossColor);
+}
+
 .TransactionsIndexPage-categoryIcon {
     width: 1em;
     text-align: center;
@@ -34,4 +42,12 @@
 
 .TransactionsIndexPage-amount {
     text-align: right;
+}
+
+.TransactionsIndexPage-amount--income {
+    color: var(--gainColor);
+}
+
+.TransactionsIndexPage-amount--expense {
+    color: var(--lossColor);
 }

--- a/src/ui/transaction/TransactionsIndexPage.js
+++ b/src/ui/transaction/TransactionsIndexPage.js
@@ -76,7 +76,7 @@ class TransactionsIndexPage extends React.Component {
                 <td className="TransactionsIndexPage-totalLabel">
                     Total
                 </td>
-                <td className="TransactionsIndexPage-total">
+                <td className={`TransactionsIndexPage-total ${transactionDayView.totalClass()}`}>
                     {transactionDayView.total()}
                 </td>
             </tr>
@@ -92,7 +92,7 @@ class TransactionsIndexPage extends React.Component {
                 <td className="TransactionsIndexPage-category">
                      {transactionRowView.category()}
                 </td>
-                <td className="TransactionsIndexPage-amount">
+                <td className={`TransactionsIndexPage-amount ${transactionRowView.amountClass()}`}>
                     {transactionRowView.amount()}
                 </td>
             </tr>

--- a/src/ui/transaction/TransactionsIndexPage.test.js
+++ b/src/ui/transaction/TransactionsIndexPage.test.js
@@ -50,6 +50,46 @@ describe('TransactionsIndexPage', () => {
         expect(cols.at(16).text()).toBe('$20.00');
     });
 
+    it('renders transaction amounts with classes based on whether they are income or expenses', () => {
+        const expense = new Transaction('id1', 20.00, new Date('2018-03-05T11:24:12.000Z'), 'General');
+        const income = new Transaction('id2', 30.00, new Date('2018-03-06T11:24:12.000Z'), 'Income');
+        const transactionHistory = new TransactionHistory([expense, income]);
+        const transactionsIndexView = new TransactionsIndexView(
+            expense.occurredAt().getMonth(),
+            transactionHistory
+        );
+
+        const transactionsIndexPage = shallow(
+            <TransactionsIndexPage transactionsIndexView={transactionsIndexView}
+        />);
+        
+        const cols = transactionsIndexPage.find('td');
+    
+        expect(cols.at(2).text()).toBe('Income');
+        expect(cols.at(3).hasClass('TransactionsIndexPage-amount--income')).toBeTruthy();
+
+        expect(cols.at(9).text()).toBe('General');
+        expect(cols.at(10).hasClass('TransactionsIndexPage-amount--expense')).toBeTruthy();
+    });
+
+    it('renders daily totals with classes based on whether there is net gain or loss', () => {
+        const expense = new Transaction('id1', 20.00, new Date('2018-03-05T11:24:12.000Z'), 'General');
+        const income = new Transaction('id2', 30.00, new Date('2018-03-06T11:24:12.000Z'), 'Income');
+        const transactionHistory = new TransactionHistory([expense, income]);
+        const transactionsIndexView = new TransactionsIndexView(
+            expense.occurredAt().getMonth(),
+            transactionHistory
+        );
+
+        const transactionsIndexPage = shallow(
+            <TransactionsIndexPage transactionsIndexView={transactionsIndexView}
+        />);
+        
+        const cols = transactionsIndexPage.find('td');
+        expect(cols.at(6).hasClass('TransactionsIndexPage-total--gain')).toBeTruthy();
+        expect(cols.at(13).hasClass('TransactionsIndexPage-total--loss')).toBeTruthy();
+    });
+
     it('renders an informative message when there are no transactions', () => {
         const transactionHistory = new TransactionHistory([]);
         const transactionsIndexView = new TransactionsIndexView(

--- a/src/ui/transaction/TransactionsIndexView.js
+++ b/src/ui/transaction/TransactionsIndexView.js
@@ -1,4 +1,5 @@
 import CategoryIconMapper from 'ui/transaction/CategoryIconMapper';
+import Transaction from 'state/Transaction';
 
 import { format } from 'date-fns';
 import { formatCurrency } from 'ui/format/CurrencyFormat';
@@ -41,7 +42,15 @@ export class TransactionDayView {
     }
 
     total() {
-        return `$${formatCurrency(this._transactionsOnDay.total())}`;
+        return `$${formatCurrency(Math.abs(this._transactionsOnDay.total()))}`;
+    }
+
+    totalClass() {
+        if(this._transactionsOnDay.total() > 0.00) {
+            return 'TransactionsIndexPage-total--loss';
+         } else {
+            return 'TransactionsIndexPage-total--gain';
+         }
     }
 
     _isoDate() {
@@ -60,6 +69,14 @@ export class TransactionRowView {
 
     amount() {
         return `$${formatCurrency(this._transaction.amount())}`;
+    }
+
+    amountClass() {
+        if(this._transaction.type() === Transaction.EXPENSE) {
+            return 'TransactionsIndexPage-amount--expense';
+        } else if(this._transaction.type() === Transaction.INCOME) {
+            return 'TransactionsIndexPage-amount--income';
+        }
     }
 
     category() {

--- a/src/ui/transaction/TransactionsIndexView.test.js
+++ b/src/ui/transaction/TransactionsIndexView.test.js
@@ -78,6 +78,48 @@ describe('TransactionDayView', () => {
 
             expect(dayView.total()).toBe('$50.00');
         });
+
+        it('returns a positive number even if the income exceeds the spend', () => {
+            const transaction1 = new Transaction('id1', 200.00, new Date('2018-03-05T11:24:12.000Z'), 'Income');
+            const transaction2 = new Transaction('id2', 30.00, new Date('2018-03-05T11:24:12.000Z'), 'General');
+            
+            const dayView = new TransactionDayView(
+                new TransactionsOnDay(
+                    transaction1.occurredAt(),
+                    [transaction1, transaction2]
+                )
+            );
+
+            expect(dayView.total()).toBe('$170.00');
+        });
+    });
+
+    describe('totalClass', () => {
+        it('returns TransactionsIndexPage-total--gain if the total is negative', () => {
+            const transaction = new Transaction('id1', 200.00, new Date('2018-03-05T11:24:12.000Z'), 'Income');
+            
+            const dayView = new TransactionDayView(
+                new TransactionsOnDay(
+                    transaction.occurredAt(),
+                    [transaction]
+                )
+            );
+
+            expect(dayView.totalClass()).toBe('TransactionsIndexPage-total--gain');
+        });
+
+        it('returns TransactionsIndexPage-total--loss if the total is positive', () => {
+            const transaction = new Transaction('id1', 200.00, new Date('2018-03-05T11:24:12.000Z'), 'General');
+            
+            const dayView = new TransactionDayView(
+                new TransactionsOnDay(
+                    transaction.occurredAt(),
+                    [transaction]
+                )
+            );
+
+            expect(dayView.totalClass()).toBe('TransactionsIndexPage-total--loss');
+        });
     });
 });
 
@@ -95,6 +137,20 @@ describe('TransactionRowView', () => {
             const transaction = new Transaction('id1', 20.00, new Date('2018-03-05T11:24:12.000Z'), 'General');
             const rowView = new TransactionRowView(transaction);
             expect(rowView.amount()).toBe('$20.00');
+        });
+    });
+
+    describe('amountClass', () => {
+        it('returns TransactionsIndexPage-amount--expense if the type of transaction is expense', () => {
+            const transaction = new Transaction('id1', 20.00, new Date('2018-03-05T11:24:12.000Z'), 'General');
+            const rowView = new TransactionRowView(transaction);
+            expect(rowView.amountClass()).toBe('TransactionsIndexPage-amount--expense');
+        });
+
+        it('returns TransactionsIndexPage-amount--income if the type of transaction is income', () => {
+            const transaction = new Transaction('id1', 20.00, new Date('2018-03-05T11:24:12.000Z'), 'Income');
+            const rowView = new TransactionRowView(transaction);
+            expect(rowView.amountClass()).toBe('TransactionsIndexPage-amount--income');
         });
     });
 

--- a/src/ui/transaction/TransactionsOnDay.js
+++ b/src/ui/transaction/TransactionsOnDay.js
@@ -1,3 +1,6 @@
+import Transaction from 'state/Transaction';
+
+
 export default class TransactionsOnDay {
     constructor(date, transactions) {
         this._date = date;
@@ -13,6 +16,6 @@ export default class TransactionsOnDay {
     }
 
     total() {
-        return this._transactions.reduce((sum, t) => sum + t.amount(), 0.00);
+        return Transaction.totalExpenses(this._transactions);
     }
 }

--- a/src/ui/transaction/TransactionsOnDay.test.js
+++ b/src/ui/transaction/TransactionsOnDay.test.js
@@ -26,10 +26,11 @@ describe('total', () => {
     it('returns the sum of all transaction amounts for the day', () => {
         const transaction1 = new Transaction('id1', 20.00, new Date('2018-03-05T11:24:12.000Z'), 'General');
         const transaction2 = new Transaction('id2', 40.00, new Date('2018-03-05T11:00:00.000Z'), 'General');
+        const transaction3 = new Transaction('id3', 10.00, new Date('2018-03-05T11:30:00.000Z'), 'Income');
         const transactionsOnDay = new TransactionsOnDay(
             transaction1.occurredAt(),
-            [transaction1, transaction2]);
+            [transaction1, transaction2, transaction3]);
 
-        expect(transactionsOnDay.total()).toBeCloseTo(60.00);
+        expect(transactionsOnDay.total()).toBeCloseTo(50.00);
     });
 });


### PR DESCRIPTION
As a user, I would like to input positive amounts into my budget, so that it can reflect my true budget. (example- Cash back from CC, or birthday money)

Acceptance Criteria:
* Add a category called "Income" and this will add money to the budget. 
* This should be reflected in the "Past Transactions" logic
