### PR TITLE
Budget summary page: Roll over current budget month to month

### DIFF
--- a/src/mollybudget/budget/model/Budget.js
+++ b/src/mollybudget/budget/model/Budget.js
@@ -18,18 +18,10 @@ export default class Budget {
     }
 
     _amountAccrued() {
-        return (new BudgetAccumulator(this._dailyBudgets)).monthToDate(this._date);
+        return (new BudgetAccumulator(this._dailyBudgets)).accumulate(this._date);
     }
 
     _amountSpent() {
-        return Transaction.totalExpenses(this._transactionsThisMonth());
-    }
-
-    _transactionsThisMonth() {
-        return this._transactions.filter((transaction) => this._occurredThisMonth(transaction));
-    }
-
-    _occurredThisMonth(transaction) {
-        return this._date.getMonth() === transaction.occurredAt().getMonth();
+        return Transaction.totalExpenses(this._transactions);
     }
 }

--- a/src/mollybudget/budget/model/Budget.test.js
+++ b/src/mollybudget/budget/model/Budget.test.js
@@ -41,19 +41,19 @@ describe('current', () => {
         expect(budget.current()).toBeCloseTo(19.00);
     });
 
-    it('ignores transactions from a previous month', () => {
-        const today = new Date('2018-04-02T11:00:00.000Z');;
+    it('includes transactions from a previous month', () => {
+        const today = new Date('2018-04-02T11:00:00.000Z');
         
         const dailyBudgets = [
             new DailyBudget('id1', 40.00, new Date('2018-01-01T11:00:00.000Z'))
         ];
         const transactions = [
             new Transaction('id1', 10.00, new Date('2018-01-01T11:00:00.000Z'), 'Disneyland'),
-            new Transaction('id2', 15.00, new Date('2018-04-02T11:00:00.000Z'), 'Knotts')
+            new Transaction('id2', 15.00, new Date('2018-01-31T11:00:00.000Z'), 'Knotts')
         ];
 
         const budget = new Budget(today, dailyBudgets, transactions);
-        expect(budget.current()).toBeCloseTo(65.00);
+        expect(budget.current()).toBeCloseTo(3615.00);
     });
 
     it('adjusts accrual rate over the course of a month based on daily budget updates', () => {
@@ -70,7 +70,6 @@ describe('current', () => {
         ];
 
         const budget = new Budget(today, dailyBudgets, transactions);
-        expect(budget.current()).toBeCloseTo(6115.00);
+        expect(budget.current()).toBeCloseTo(9675.00);
     });
-
 });

--- a/src/mollybudget/budget/model/BudgetAccumulator.test.js
+++ b/src/mollybudget/budget/model/BudgetAccumulator.test.js
@@ -2,26 +2,26 @@ import BudgetAccumulator from 'mollybudget/budget/model/BudgetAccumulator';
 import DailyBudget from 'mollybudget/settings/model/DailyBudget';
 
 
-describe('monthToDate', () => {
+describe('accumulate', () => {
     it('returns 10.00 for one day with a daily budget of 10.00', () => {
         const april1 = new Date('2018-04-01T11:00:00.000Z');
         const april2 = new Date('2018-04-02T11:00:00.000Z');
         const accumulator = new BudgetAccumulator([new DailyBudget('id1', 10.00, april1)]);
-        expect(accumulator.monthToDate(april2)).toBeCloseTo(10.00);
+        expect(accumulator.accumulate(april2)).toBeCloseTo(10.00);
     });
 
     it('returns 20.00 for two days with a daily budget of 10.00', () => {
         const april1 = new Date('2018-04-01T11:00:00.000Z');
         const april3 = new Date('2018-04-03T11:00:00.000Z');
         const accumulator = new BudgetAccumulator([new DailyBudget('id1', 10.00, april1)]);
-        expect(accumulator.monthToDate(april3)).toBeCloseTo(20.00);
+        expect(accumulator.accumulate(april3)).toBeCloseTo(20.00);
     });
 
     it('returns 40.00 for two days with a daily budget of 20.00', () => {
         const april1 = new Date('2018-04-01T11:00:00.000Z');
         const april3 = new Date('2018-04-03T11:00:00.000Z');
         const accumulator = new BudgetAccumulator([new DailyBudget('id1', 20.00, april1)]);
-        expect(accumulator.monthToDate(april3)).toBeCloseTo(40.00);
+        expect(accumulator.accumulate(april3)).toBeCloseTo(40.00);
     });
 
     it('returns 50.00 for two days with a daily budget of 20.00 and one day with a daily budget of 10.00', () => {
@@ -32,7 +32,7 @@ describe('monthToDate', () => {
             new DailyBudget('id1', 20.00, april1),
             new DailyBudget('id2', 10.00, april3)
         ]);
-        expect(accumulator.monthToDate(april4)).toBeCloseTo(50.00);
+        expect(accumulator.accumulate(april4)).toBeCloseTo(50.00);
     });
 
     it('ignores obsolete daily budgets created within the same day', () => {
@@ -45,7 +45,7 @@ describe('monthToDate', () => {
             new DailyBudget('id3', 2000.00, april2),
             new DailyBudget('id4', 37.00, april2)
         ]);
-        expect(accumulator.monthToDate(april3)).toBeCloseTo(57.00);
+        expect(accumulator.accumulate(april3)).toBeCloseTo(57.00);
     });
 
     it('ensures that daily budget changes do not take effect on the current day', () => {
@@ -55,7 +55,7 @@ describe('monthToDate', () => {
             new DailyBudget('id1', 20.00, april1),
             new DailyBudget('id2', 1000.00, april2),
         ]);
-        expect(accumulator.monthToDate(april2)).toBeCloseTo(20.00);
+        expect(accumulator.accumulate(april2)).toBeCloseTo(20.00);
     });
 
     it('ignores future daily budgets', () => {
@@ -68,24 +68,13 @@ describe('monthToDate', () => {
             new DailyBudget('id2', 10.00, april2),
             new DailyBudget('id3', 2000.00, april4)
         ]);
-        expect(accumulator.monthToDate(april3)).toBeCloseTo(30.00);
-    });
-
-    it('uses the latest daily budget if no daily budgets have been added in the current month', () => {
-        const march14 = new Date('2018-03-14T00:00:00.000Z');
-        const march15 = new Date('2018-03-15T00:00:00.000Z');
-        const april2 = new Date('2018-04-02T11:00:00.000Z');
-        const accumulator = new BudgetAccumulator([
-            new DailyBudget('id1', 3000.00, march14),
-            new DailyBudget('id2', 20.00, march15)
-        ]);
-        expect(accumulator.monthToDate(april2)).toBeCloseTo(40.00);
+        expect(accumulator.accumulate(april3)).toBeCloseTo(30.00);
     });
 
     it('returns 0.00 if no daily budget has been configured', () => {
         const april2 = new Date('2018-04-02T11:00:00.000Z');
         const accumulator = new BudgetAccumulator([]);
-        expect(accumulator.monthToDate(april2)).toBeCloseTo(0.00);
+        expect(accumulator.accumulate(april2)).toBeCloseTo(0.00);
     });
 
     it('returns 0.00 if only future daily budgets exist', () => {
@@ -94,7 +83,27 @@ describe('monthToDate', () => {
         const accumulator = new BudgetAccumulator([
             new DailyBudget('id3', 3000.00, april20)
         ]);
-        expect(accumulator.monthToDate(april5)).toBeCloseTo(0.00);
+        expect(accumulator.accumulate(april5)).toBeCloseTo(0.00);
+    });
+
+    it('accumulates the budget across month boundaries', () => {
+        const march30 = new Date('2018-03-30T00:00:00.000Z');
+        const april2 = new Date('2018-04-02T00:00:00.000Z');
+        const accumulator = new BudgetAccumulator([
+            new DailyBudget('id1', 3000.00, march30)
+        ]);
+        expect(accumulator.accumulate(april2)).toBeCloseTo(9000.00);
+    });
+
+    it('uses the latest daily budget if no daily budgets have been added in the current month', () => {
+        const march14 = new Date('2018-03-14T08:00:00.000Z');
+        const march15 = new Date('2018-03-15T10:00:00.000Z');
+        const april2 = new Date('2018-04-02T11:00:00.000Z');
+        const accumulator = new BudgetAccumulator([
+            new DailyBudget('id1', 3000.00, march14),
+            new DailyBudget('id2', 4000.00, march15)
+        ]);
+        expect(accumulator.accumulate(april2)).toBeCloseTo(75000.00);
     });
 
     it('rolls over daily budget from a previous month and adjusts to updates in the current month', () => {
@@ -107,6 +116,6 @@ describe('monthToDate', () => {
             new DailyBudget('id2', 20.00, april2),
             new DailyBudget('id3', 3000.00, april20)
         ]);
-        expect(accumulator.monthToDate(april5)).toBeCloseTo(160.00);
+        expect(accumulator.accumulate(april5)).toBeCloseTo(960.00);
     });
 });


### PR DESCRIPTION
As a user, I want my monthly balance to rollover on the budget summary page, so that I can continue to stay on budget as each month passes by. 

Acceptance Criteria:
* At the end of each month, the balance rolls over to the next month on the budget summary page, weather positive or negative. 