### PR TITLE
Display rollover amount on transactions page

### DIFF
--- a/src/mollybudget/app/ui/App.js
+++ b/src/mollybudget/app/ui/App.js
@@ -33,6 +33,7 @@ class App extends React.Component {
                 <AppRoutes
                     appStore={this.props.appStore}
                     budget={this._budget()}
+                    dateSnapshot={new Date()}
                     location={this.props.location}
                 />
                 </PageTransition>

--- a/src/mollybudget/app/ui/App.js
+++ b/src/mollybudget/app/ui/App.js
@@ -41,7 +41,8 @@ class App extends React.Component {
     }
 
     _budget() {
-        return Budget.create(
+        return new Budget(
+            new Date(),
             this.props.appStore.dailyBudgetStore().dailyBudgets(),
             this.props.appStore.transactionStore().transactions()
         );

--- a/src/mollybudget/app/ui/App.js
+++ b/src/mollybudget/app/ui/App.js
@@ -43,7 +43,6 @@ class App extends React.Component {
 
     _budget() {
         return new Budget(
-            new Date(),
             this.props.appStore.dailyBudgetStore().dailyBudgets(),
             this.props.appStore.transactionStore().transactions()
         );

--- a/src/mollybudget/app/ui/AppRoutes.js
+++ b/src/mollybudget/app/ui/AppRoutes.js
@@ -25,6 +25,7 @@ class AppRoutes extends React.Component {
                 <Route path="/transactions" render={({ history }) => (
                     <TransactionRoutes
                         transactionStore={this.props.appStore.transactionStore()}
+                        budget={this.props.budget}
                         dateSnapshot={this.props.dateSnapshot}
                         history={history}
                         location={this.props.location}

--- a/src/mollybudget/app/ui/AppRoutes.js
+++ b/src/mollybudget/app/ui/AppRoutes.js
@@ -24,6 +24,7 @@ class AppRoutes extends React.Component {
                 <Route path="/transactions" render={({ history }) => (
                     <TransactionRoutes
                         transactionStore={this.props.appStore.transactionStore()}
+                        dateSnapshot={this.props.dateSnapshot}
                         history={history}
                         location={this.props.location}
                     />)}
@@ -42,6 +43,7 @@ class AppRoutes extends React.Component {
 AppRoutes.propTypes = {
     appStore: PropTypes.object.isRequired,
     budget: PropTypes.object.isRequired,
+    dateSnapshot: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired
 };
 

--- a/src/mollybudget/app/ui/AppRoutes.js
+++ b/src/mollybudget/app/ui/AppRoutes.js
@@ -16,6 +16,7 @@ class AppRoutes extends React.Component {
                     <BudgetSummaryPage
                         user={this.props.appStore.user()}
                         budget={this.props.budget}
+                        dateSnapshot={this.props.dateSnapshot}
                         history={history}
                         location={this.props.location}
                     />)}

--- a/src/mollybudget/app/ui/AppRoutes.test.js
+++ b/src/mollybudget/app/ui/AppRoutes.test.js
@@ -3,9 +3,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { shallow, mount } from 'enzyme';
 
 import AppRoutes from 'mollybudget/app/ui/AppRoutes';
-import BudgetSummaryPage from 'mollybudget/budget/ui/BudgetSummaryPage';
 import TransactionRoutes from 'mollybudget/transaction/ui/TransactionRoutes';
+
 import SettingsRoutes from 'mollybudget/settings/ui/SettingsRoutes';
+import DailyBudget from 'mollybudget/settings/model/DailyBudget';
+
+import BudgetSummaryPage from 'mollybudget/budget/ui/BudgetSummaryPage';
 import Budget from 'mollybudget/budget/model/Budget';
 
 
@@ -30,7 +33,7 @@ describe('AppRoutes', () => {
 
     it('renders TransactionAmountPage when the user navigates to /transactions', () => {
         const today = new Date();
-        const budget = new Budget(10.00, []);
+        const budget = new Budget([], []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/transactions']}>
                 <AppRoutes
@@ -48,7 +51,7 @@ describe('AppRoutes', () => {
 
     it('renders SettingsRoutes when the user navigates to /settings', () => {
         const today = new Date();
-        const budget = new Budget(10.00, []);
+        const budget = new Budget([], []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/settings']}>
                 <AppRoutes

--- a/src/mollybudget/app/ui/AppRoutes.test.js
+++ b/src/mollybudget/app/ui/AppRoutes.test.js
@@ -12,7 +12,7 @@ import Budget from 'mollybudget/budget/model/Budget';
 describe('AppRoutes', () => {
     it('renders BudgetSummaryPage when the user navigates to /', () => {
         const today = new Date();
-        const budget = new Budget(today, [], []);
+        const budget = new Budget([], []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/']}>
                 <AppRoutes
@@ -30,7 +30,7 @@ describe('AppRoutes', () => {
 
     it('renders TransactionAmountPage when the user navigates to /transactions', () => {
         const today = new Date();
-        const budget = new Budget(today, 10.00, []);
+        const budget = new Budget(10.00, []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/transactions']}>
                 <AppRoutes
@@ -48,7 +48,7 @@ describe('AppRoutes', () => {
 
     it('renders SettingsRoutes when the user navigates to /settings', () => {
         const today = new Date();
-        const budget = new Budget(today, 10.00, []);
+        const budget = new Budget(10.00, []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/settings']}>
                 <AppRoutes

--- a/src/mollybudget/app/ui/AppRoutes.test.js
+++ b/src/mollybudget/app/ui/AppRoutes.test.js
@@ -11,10 +11,16 @@ import Budget from 'mollybudget/budget/model/Budget';
 
 describe('AppRoutes', () => {
     it('renders BudgetSummaryPage when the user navigates to /', () => {
-        const budget = new Budget(new Date(), [], []);
+        const today = new Date();
+        const budget = new Budget(today, [], []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/']}>
-                <AppRoutes appStore={_appStore()} budget={budget} location={{}} />
+                <AppRoutes
+                    appStore={_appStore()}
+                    budget={budget}
+                    dateSnapshot={today}
+                    location={{}}
+                />
             </MemoryRouter>
         );
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(1);
@@ -23,10 +29,16 @@ describe('AppRoutes', () => {
     });
 
     it('renders TransactionAmountPage when the user navigates to /transactions', () => {
-        const budget = new Budget(new Date(), 10.00, []);
+        const today = new Date();
+        const budget = new Budget(today, 10.00, []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/transactions']}>
-                <AppRoutes appStore={_appStore()} budget={budget} location={{}}/>
+                <AppRoutes
+                    appStore={_appStore()}
+                    budget={budget}
+                    dateSnapshot={today}
+                    location={{}}
+                />
             </MemoryRouter>
         );
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);
@@ -35,10 +47,16 @@ describe('AppRoutes', () => {
     });
 
     it('renders SettingsRoutes when the user navigates to /settings', () => {
-        const budget = new Budget(new Date(), 10.00, []);
+        const today = new Date();
+        const budget = new Budget(today, 10.00, []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/settings']}>
-                <AppRoutes appStore={_appStore()} budget={budget} location={{}}/>
+                <AppRoutes
+                    appStore={_appStore()}
+                    budget={budget}
+                    dateSnapshot={today}
+                    location={{}}
+                />
             </MemoryRouter>
         );
         expect(wrapper.find(BudgetSummaryPage)).toHaveLength(0);

--- a/src/mollybudget/app/ui/AppRoutes.test.js
+++ b/src/mollybudget/app/ui/AppRoutes.test.js
@@ -11,7 +11,7 @@ import Budget from 'mollybudget/budget/model/Budget';
 
 describe('AppRoutes', () => {
     it('renders BudgetSummaryPage when the user navigates to /', () => {
-        const budget = Budget.create([], []);
+        const budget = new Budget(new Date(), [], []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/']}>
                 <AppRoutes appStore={_appStore()} budget={budget} location={{}} />
@@ -23,7 +23,7 @@ describe('AppRoutes', () => {
     });
 
     it('renders TransactionAmountPage when the user navigates to /transactions', () => {
-        const budget = Budget.create(10.00, []);
+        const budget = new Budget(new Date(), 10.00, []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/transactions']}>
                 <AppRoutes appStore={_appStore()} budget={budget} location={{}}/>
@@ -35,7 +35,7 @@ describe('AppRoutes', () => {
     });
 
     it('renders SettingsRoutes when the user navigates to /settings', () => {
-        const budget = Budget.create(10.00, []);
+        const budget = new Budget(new Date(), 10.00, []);
         const wrapper = mount(
             <MemoryRouter initialEntries={['/settings']}>
                 <AppRoutes appStore={_appStore()} budget={budget} location={{}}/>

--- a/src/mollybudget/budget/model/Budget.js
+++ b/src/mollybudget/budget/model/Budget.js
@@ -9,14 +9,18 @@ export default class Budget {
     }
 
     totalToDate(date) {
-        return this._amountAccrued(date) - this._amountSpent();
+        return this._amountAccrued(date) - this._amountSpent(date);
     }
 
     _amountAccrued(date) {
         return (new BudgetAccumulator(this._dailyBudgets)).accumulate(date);
     }
 
-    _amountSpent() {
-        return Transaction.totalExpenses(this._transactions);
+    _amountSpent(date) {
+        return Transaction.totalExpenses(this._withoutFutures(date, this._transactions));
+    }
+
+    _withoutFutures(date, transactions) {
+        return transactions.filter((transaction) => transaction.occurredAt() <= date);
     }
 }

--- a/src/mollybudget/budget/model/Budget.js
+++ b/src/mollybudget/budget/model/Budget.js
@@ -3,18 +3,17 @@ import Transaction from 'mollybudget/transaction/model/Transaction';
 
 
 export default class Budget {
-    constructor(date, dailyBudgets, transactions) {
-        this._date = date;
+    constructor(dailyBudgets, transactions) {
         this._dailyBudgets = dailyBudgets;
         this._transactions = transactions;
     }
 
-    current() {
-        return this._amountAccrued() - this._amountSpent();
+    totalToDate(date) {
+        return this._amountAccrued(date) - this._amountSpent();
     }
 
-    _amountAccrued() {
-        return (new BudgetAccumulator(this._dailyBudgets)).accumulate(this._date);
+    _amountAccrued(date) {
+        return (new BudgetAccumulator(this._dailyBudgets)).accumulate(date);
     }
 
     _amountSpent() {

--- a/src/mollybudget/budget/model/Budget.js
+++ b/src/mollybudget/budget/model/Budget.js
@@ -3,10 +3,6 @@ import Transaction from 'mollybudget/transaction/model/Transaction';
 
 
 export default class Budget {
-    static create(dailyBudgets, transactions) {
-        return new Budget(new Date(), dailyBudgets, transactions);
-    }
-
     constructor(date, dailyBudgets, transactions) {
         this._date = date;
         this._dailyBudgets = dailyBudgets;

--- a/src/mollybudget/budget/model/Budget.test.js
+++ b/src/mollybudget/budget/model/Budget.test.js
@@ -3,27 +3,6 @@ import DailyBudget from 'mollybudget/settings/model/DailyBudget';
 import Transaction from 'mollybudget/transaction/model/Transaction';
 
 
-describe('create', () => {
-    it('returns a budget configured with the current date', () => {
-        const savedDate = Date;
-        const today = new Date('2018-04-05T11:00:00.000Z');
-
-        const dailyBudgets = [
-            new DailyBudget('id1', 8.00, new Date('2018-04-01T11:00:00.000Z'))
-        ];
-        const transactions = [
-            new Transaction('id1', 10.00, new Date('2018-04-02T11:00:00.000Z'), 'Disneyland')
-        ];
-        
-        // Mock the date constructor and restore it after creating a budget
-        Date = jest.fn(() => today);
-        const budget = Budget.create(dailyBudgets, transactions);
-        Date = savedDate;
-
-        expect(budget.current()).toBeCloseTo(22.00);
-    });
-});
-
 describe('current', () => {
     it('returns the amount accrued or received as income minus the amount spent', () => {
         const today = new Date('2018-04-02T11:00:00.000Z');;

--- a/src/mollybudget/budget/model/Budget.test.js
+++ b/src/mollybudget/budget/model/Budget.test.js
@@ -35,6 +35,17 @@ describe('totalToDate', () => {
         expect(budget.totalToDate(today)).toBeCloseTo(3615.00);
     });
 
+    it('excludes transactions in the future', () => {
+        const today = new Date('2018-04-02T11:00:00.000Z');
+        const transactions = [
+            new Transaction('id1', 10.00, new Date('2018-04-01T11:00:00.000Z'), 'Disneyland'),
+            new Transaction('id2', 15.00, new Date('2018-04-03T11:00:00.000Z'), 'Knotts')
+        ];
+
+        const budget = new Budget([], transactions);
+        expect(budget.totalToDate(today)).toBeCloseTo(-10.00);
+    });
+
     it('adjusts accrual rate over the course of a month based on daily budget updates', () => {
         const today = new Date('2018-04-07T11:00:00.000Z');;
         

--- a/src/mollybudget/budget/model/Budget.test.js
+++ b/src/mollybudget/budget/model/Budget.test.js
@@ -3,7 +3,7 @@ import DailyBudget from 'mollybudget/settings/model/DailyBudget';
 import Transaction from 'mollybudget/transaction/model/Transaction';
 
 
-describe('current', () => {
+describe('totalToDate', () => {
     it('returns the amount accrued or received as income minus the amount spent', () => {
         const today = new Date('2018-04-02T11:00:00.000Z');;
         
@@ -16,8 +16,8 @@ describe('current', () => {
             new Transaction('id2', 4.00, new Date('2018-04-02T11:00:00.000Z'), 'Income')
         ];
 
-        const budget = new Budget(today, dailyBudgets, transactions);
-        expect(budget.current()).toBeCloseTo(19.00);
+        const budget = new Budget(dailyBudgets, transactions);
+        expect(budget.totalToDate(today)).toBeCloseTo(19.00);
     });
 
     it('includes transactions from a previous month', () => {
@@ -31,8 +31,8 @@ describe('current', () => {
             new Transaction('id2', 15.00, new Date('2018-01-31T11:00:00.000Z'), 'Knotts')
         ];
 
-        const budget = new Budget(today, dailyBudgets, transactions);
-        expect(budget.current()).toBeCloseTo(3615.00);
+        const budget = new Budget(dailyBudgets, transactions);
+        expect(budget.totalToDate(today)).toBeCloseTo(3615.00);
     });
 
     it('adjusts accrual rate over the course of a month based on daily budget updates', () => {
@@ -48,7 +48,7 @@ describe('current', () => {
             new Transaction('id2', 15.00, new Date('2018-04-03T11:00:00.000Z'), 'Knotts')
         ];
 
-        const budget = new Budget(today, dailyBudgets, transactions);
-        expect(budget.current()).toBeCloseTo(9675.00);
+        const budget = new Budget(dailyBudgets, transactions);
+        expect(budget.totalToDate(today)).toBeCloseTo(9675.00);
     });
 });

--- a/src/mollybudget/budget/ui/BudgetSummaryPage.js
+++ b/src/mollybudget/budget/ui/BudgetSummaryPage.js
@@ -41,7 +41,7 @@ class BudgetSummaryPage extends React.Component {
     }
 
     _amount() {
-        return formatCurrency(this.props.budget.current());
+        return formatCurrency(this.props.budget.totalToDate(this.props.dateSnapshot));
     }
 
     _onAddTransactionClicked() {
@@ -56,6 +56,7 @@ class BudgetSummaryPage extends React.Component {
 BudgetSummaryPage.propTypes = {
     user: PropTypes.object.isRequired,
     budget: PropTypes.object.isRequired,
+    dateSnapshot: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired
 };
 

--- a/src/mollybudget/budget/ui/BudgetSummaryPage.test.js
+++ b/src/mollybudget/budget/ui/BudgetSummaryPage.test.js
@@ -1,19 +1,19 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import BudgetSummary from 'mollybudget/budget/ui/BudgetSummaryPage';
+import BudgetSummaryPage from 'mollybudget/budget/ui/BudgetSummaryPage';
 import Budget from 'mollybudget/budget/model/Budget';
 import DailyBudget from 'mollybudget/settings/model/DailyBudget';
 import { Button } from 'reactstrap';
 
 
-describe('BudgetSummary', () => {
+describe('BudgetSummaryPage', () => {
     it('renders the current user\'s display name and current budget', () => {
         const user = { displayName: 'Fred Rogers' };
         const dailyBudget = new DailyBudget('id1', 50.00, new Date('2018-02-12T11:00:00.000Z'));
         const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [dailyBudget], []);
         const history = { push: jest.fn() };
-        const budgetSummary = shallow(<BudgetSummary user={user} budget={budget} history={history}/>);
+        const budgetSummary = shallow(<BudgetSummaryPage user={user} budget={budget} history={history}/>);
 
         expect(budgetSummary.find('.BudgetSummaryPage-summary').text())
             .toBe('Hello Fred Rogers,you have $150.00 to spend today.');
@@ -23,7 +23,7 @@ describe('BudgetSummary', () => {
         const user = { displayName: 'Fred Rogers' };
         const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [], []);
         const history = { push: jest.fn() };
-        const budgetSummary = shallow(<BudgetSummary user={user} budget={budget} history={history}/>);
+        const budgetSummary = shallow(<BudgetSummaryPage user={user} budget={budget} history={history}/>);
 
         budgetSummary.find('.BudgetSummaryPage-addTransaction').simulate('click');
         expect(history.push).toHaveBeenCalledWith('/transactions/new');
@@ -33,7 +33,7 @@ describe('BudgetSummary', () => {
         const user = { displayName: 'Fred Rogers' };
         const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [], []);
         const history = { push: jest.fn() };
-        const budgetSummary = shallow(<BudgetSummary user={user} budget={budget} history={history}/>);
+        const budgetSummary = shallow(<BudgetSummaryPage user={user} budget={budget} history={history}/>);
 
         budgetSummary.find('.BudgetSummaryPage-viewPastTransactions').simulate('click');
         expect(history.push).toHaveBeenCalledWith('/transactions');

--- a/src/mollybudget/budget/ui/BudgetSummaryPage.test.js
+++ b/src/mollybudget/budget/ui/BudgetSummaryPage.test.js
@@ -11,9 +11,18 @@ describe('BudgetSummaryPage', () => {
     it('renders the current user\'s display name and current budget', () => {
         const user = { displayName: 'Fred Rogers' };
         const dailyBudget = new DailyBudget('id1', 50.00, new Date('2018-02-12T11:00:00.000Z'));
-        const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [dailyBudget], []);
+        const today = new Date('2018-02-15T11:00:00.000Z')
+        const budget = new Budget([dailyBudget], []);
         const history = { push: jest.fn() };
-        const budgetSummary = shallow(<BudgetSummaryPage user={user} budget={budget} history={history}/>);
+        
+        const budgetSummary = shallow(
+            <BudgetSummaryPage
+                user={user}
+                budget={budget}
+                dateSnapshot={today}
+                history={history}
+            />
+        );
 
         expect(budgetSummary.find('.BudgetSummaryPage-summary').text())
             .toBe('Hello Fred Rogers,you have $150.00 to spend today.');
@@ -21,9 +30,18 @@ describe('BudgetSummaryPage', () => {
 
     it('navigates to /transactions/new when the add transaction button is clicked', () => {
         const user = { displayName: 'Fred Rogers' };
-        const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [], []);
+        const budget = new Budget([], []);
+        const today = new Date('2018-02-15T11:00:00.000Z');
         const history = { push: jest.fn() };
-        const budgetSummary = shallow(<BudgetSummaryPage user={user} budget={budget} history={history}/>);
+        
+        const budgetSummary = shallow(
+            <BudgetSummaryPage
+                user={user}
+                budget={budget}
+                dateSnapshot={today}
+                history={history}
+            />
+        );
 
         budgetSummary.find('.BudgetSummaryPage-addTransaction').simulate('click');
         expect(history.push).toHaveBeenCalledWith('/transactions/new');
@@ -31,9 +49,18 @@ describe('BudgetSummaryPage', () => {
 
     it('navigates to /transactions when the view past transactions button is clicked', () => {
         const user = { displayName: 'Fred Rogers' };
-        const budget = new Budget(new Date('2018-02-15T11:00:00.000Z'), [], []);
+        const budget = new Budget([], []);
+        const today = new Date('2018-02-15T11:00:00.000Z');
         const history = { push: jest.fn() };
-        const budgetSummary = shallow(<BudgetSummaryPage user={user} budget={budget} history={history}/>);
+        
+        const budgetSummary = shallow(
+            <BudgetSummaryPage
+                user={user}
+                budget={budget}
+                dateSnapshot={today}
+                history={history}
+            />
+        );
 
         budgetSummary.find('.BudgetSummaryPage-viewPastTransactions').simulate('click');
         expect(history.push).toHaveBeenCalledWith('/transactions');

--- a/src/mollybudget/transaction/model/RolloverTransaction.js
+++ b/src/mollybudget/transaction/model/RolloverTransaction.js
@@ -1,0 +1,29 @@
+import Transaction from 'mollybudget/transaction/model/Transaction';
+
+export default class RolloverTransaction {
+    constructor(id, signedAmount, occurredAt) {
+        this._id = id;
+        this._signedAmount = signedAmount;
+        this._occurredAt = occurredAt;
+    }
+
+    id() {
+        return this._id;
+    }
+
+    type() {
+        return this._signedAmount < 0.00 ? Transaction.EXPENSE : Transaction.INCOME;
+    }
+
+    amount() {
+        return Math.abs(this._signedAmount);
+    }
+
+    occurredAt() {
+        return this._occurredAt;
+    }
+
+    category() {
+        return 'Rollover';
+    }
+}

--- a/src/mollybudget/transaction/model/RolloverTransaction.test.js
+++ b/src/mollybudget/transaction/model/RolloverTransaction.test.js
@@ -1,0 +1,50 @@
+import RolloverTransaction from 'mollybudget/transaction/model/RolloverTransaction';
+import Transaction from 'mollybudget/transaction/model/Transaction';
+
+
+
+describe('id', () => {
+    it('returns the transaction id', () => {
+        const transaction = new RolloverTransaction('id', 12.3, new Date());
+        expect(transaction.id()).toBe('id');
+    });
+});
+
+describe('type', () => {
+    it('returns the income type for a transaction with a zero amount', () => {
+        const transaction = new RolloverTransaction('id', 0.00, new Date());
+        expect(transaction.type()).toBe(Transaction.INCOME);
+    });
+
+    it('returns the income type for a transaction with a positive amount', () => {
+        const transaction = new RolloverTransaction('id', 1.00, new Date());
+        expect(transaction.type()).toBe(Transaction.INCOME);
+    });
+
+    it('returns the expense type for a transaction with a negative amount', () => {
+        const transaction = new RolloverTransaction('id', -1.00, new Date());
+        expect(transaction.type()).toBe(Transaction.EXPENSE);
+    });
+});
+
+describe('amount', () => {
+    it('returns the transaction amount as an absolute value', () => {
+        const transaction = new RolloverTransaction('id', -12.3, new Date());
+        expect(transaction.amount()).toBeCloseTo(12.3);
+    });
+});
+
+describe('occurredAt', () => {
+    it('returns the date and time the transaction occurred at', () => {
+        const occurredAt = new Date('2018-04-30T11:24:12.000Z');
+        const transaction = new RolloverTransaction('id', 12.3, occurredAt);
+        expect(transaction.occurredAt()).toBe(occurredAt);
+    });
+});
+
+describe('category', () => {
+    it('returns "Rollover"', () => {
+        const transaction = new RolloverTransaction('id', 12.3, new Date());
+        expect(transaction.category()).toBe('Rollover');
+    });
+});

--- a/src/mollybudget/transaction/model/TransactionHistory.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.js
@@ -1,9 +1,13 @@
 import TransactionsOnDay from 'mollybudget/transaction/model/TransactionsOnDay';
-import { startOfMonth } from 'date-fns';
 import Transaction from './Transaction';
+import { startOfMonth } from 'date-fns';
 
 
 export default class TransactionHistory {
+    static createWithRollover(asOfDate, transactions, budget) {
+        return new TransactionHistory(transactions, budget.totalToDate(startOfMonth(asOfDate)));
+    }
+
     constructor(transactions, rolloverAmount = null) {
         this._transactions = transactions;
         this._rolloverAmount = rolloverAmount

--- a/src/mollybudget/transaction/model/TransactionHistory.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.js
@@ -1,5 +1,6 @@
 import TransactionsOnDay from 'mollybudget/transaction/model/TransactionsOnDay';
-import Transaction from './Transaction';
+import Transaction from 'mollybudget/transaction/model/Transaction';
+import RolloverTransaction from 'mollybudget/transaction/model/RolloverTransaction';
 import { startOfMonth } from 'date-fns';
 
 
@@ -58,11 +59,10 @@ export default class TransactionHistory {
     }
 
     _rolloverTransaction(amount, date) {
-        return new Transaction(
+        return new RolloverTransaction(
             'rolloverId',
             amount,
-            startOfMonth(date),
-            'Rollover'
+            startOfMonth(date)
         );
     }
 }

--- a/src/mollybudget/transaction/model/TransactionHistory.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.js
@@ -18,7 +18,7 @@ export default class TransactionHistory {
 
     inMonthByDay(date) {
         return this._transactionGroups(this._transactions, date).map(
-            (group) => (new TransactionsOnDay(group[0].occurredAt(), group))
+            (group) => this._transactionsByDay(group)
         );
     }
 
@@ -64,12 +64,16 @@ export default class TransactionHistory {
             }
             group.push(transaction);
         });
-        return Array.from(groups.values()).sort();
+        return Array.from(groups.values());
     }
 
     _withRollover(transactions, date) {
         if(this._rolloverAmountFunc !== null) {
-            return [this._rolloverTransaction(this._rolloverAmountFunc(), date), ...transactions];
+            const rollover = this._rolloverTransaction(
+                this._rolloverAmountFunc(),
+                date
+            );
+            return [rollover, ...transactions];
         } else {
             return transactions;
         }
@@ -92,7 +96,7 @@ export default class TransactionHistory {
 
     _oldestFirst(transactions) {
         return Array.from(transactions).sort(
-            (t1, t2) => t2.occurredAt() - t1.occurredAt()
+            (t1, t2) => t1.occurredAt() - t2.occurredAt()
         );
     }
 }

--- a/src/mollybudget/transaction/model/TransactionHistory.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.js
@@ -1,4 +1,5 @@
 import TransactionsOnDay from 'mollybudget/transaction/model/TransactionsOnDay';
+import { startOfMonth } from 'date-fns';
 
 
 export default class TransactionHistory {
@@ -6,10 +7,14 @@ export default class TransactionHistory {
         this._transactions = transactions;
     }
 
-    inMonthByDay(month) {
-        return this._byDay(this._newestFirst(this._inMonth(month, this._transactions))).map(
-            (group) => (new TransactionsOnDay(group[0].occurredAt(), group)
-        ));
+    inMonthByDay(date) {
+        return this._transactionGroups(this._transactions, date).map(
+            (group) => (new TransactionsOnDay(group[0].occurredAt(), group))
+        );
+    }
+
+    _transactionGroups(transactions, date) {
+        return this._byDay(this._newestFirst(this._inMonth(date.getMonth(), this._transactions)));
     }
 
     _inMonth(month, transactions) {

--- a/src/mollybudget/transaction/model/TransactionHistory.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.js
@@ -7,13 +7,13 @@ export default class TransactionHistory {
     static createWithRollover(asOfDate, transactions, budget) {
         return new TransactionHistory(
             transactions,
-            budget.totalToDate(startOfMonth(asOfDate))
+            () => budget.totalToDate(startOfMonth(asOfDate))
         );
     }
 
-    constructor(transactions, rolloverAmount = null) {
+    constructor(transactions, rolloverAmountFunc = null) {
         this._transactions = transactions;
-        this._rolloverAmount = rolloverAmount
+        this._rolloverAmountFunc = rolloverAmountFunc
     }
 
     inMonthByDay(date) {
@@ -68,8 +68,8 @@ export default class TransactionHistory {
     }
 
     _withRollover(transactions, date) {
-        if(this._rolloverAmount !== null) {
-            return [this._rolloverTransaction(this._rolloverAmount, date), ...transactions];
+        if(this._rolloverAmountFunc !== null) {
+            return [this._rolloverTransaction(this._rolloverAmountFunc(), date), ...transactions];
         } else {
             return transactions;
         }

--- a/src/mollybudget/transaction/model/TransactionHistory.test.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.test.js
@@ -36,9 +36,9 @@ describe('inMonthByDay', () => {
         expect(transactionHistory.inMonthByDay(date)).toEqual([]);
     });
 
-    it('returns a transaction group specifying the rollover amount, if specified', () => {
+    it('returns a transaction group specifying the rollover amount, if a rollover function is specified', () => {
         const date = new Date('2018-05-05T11:24:12.000Z');
-        const transactionHistory = new TransactionHistory([], 123.12);
+        const transactionHistory = new TransactionHistory([], () => 123.12);
         
         const transactionsByDay = transactionHistory.inMonthByDay(date);
         expect(transactionsByDay).toHaveLength(1);
@@ -53,7 +53,7 @@ describe('inMonthByDay', () => {
     it('allows the rollover amount to be coupled with other transactions on the first of the month', () => {
         const may1 = new Date('2018-05-01T11:24:12.000Z');
         const transaction = new Transaction('id1', 10.00, may1, 'General');
-        const transactionHistory = new TransactionHistory([transaction], 111.10);
+        const transactionHistory = new TransactionHistory([transaction], () => 111.10);
         
         const transactionsByDay = transactionHistory.inMonthByDay(may1);
         expect(transactionsByDay).toHaveLength(1);
@@ -73,7 +73,7 @@ describe('inMonthByDay', () => {
         const may1 = new Date('2018-05-01T11:24:12.000Z');
         const may2 = new Date('2018-05-02T11:24:12.000Z');
         const transaction = new Transaction('id1', 10.00, may2, 'General');
-        const transactionHistory = new TransactionHistory([transaction], 111.10);
+        const transactionHistory = new TransactionHistory([transaction], () => 111.10);
         
         const transactionsByDay = transactionHistory.inMonthByDay(may1);
         expect(transactionsByDay).toHaveLength(2);

--- a/src/mollybudget/transaction/model/TransactionHistory.test.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.test.js
@@ -80,6 +80,7 @@ describe('inMonthByDay', () => {
 
         expect(transactionsByDay[0].date().getDate()).toBe(1);
         expect(transactionsByDay[0].transactions()).toHaveLength(1);
+        expect(transactionsByDay[0].transactions()[0].id()).toBe('rolloverId');
         expect(transactionsByDay[0].transactions()[0].occurredAt().getDate()).toBe(1);
         expect(transactionsByDay[0].transactions()[0].amount()).toBeCloseTo(111.10);
         expect(transactionsByDay[0].transactions()[0].category()).toBe('Rollover');

--- a/src/mollybudget/transaction/model/TransactionHistory.test.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.test.js
@@ -4,15 +4,16 @@ import Transaction from 'mollybudget/transaction/model/Transaction';
 
 describe('inMonthByDay', () => {
     it('returns an empty array when there are no transactions', () => {
+        const date = new Date('2018-05-05T11:24:12.000Z');
         const transactionHistory = new TransactionHistory([]);
-        expect(transactionHistory.inMonthByDay(5)).toEqual([]);
+        expect(transactionHistory.inMonthByDay(date)).toEqual([]);
     });
 
     it('returns a single group of transactions if only one transaction exists in the given month', () => {
         const transaction = new Transaction('id1', 10.00, new Date('2018-05-05T11:24:12.000Z'), 'General');
         const transactionHistory = new TransactionHistory([transaction]);
         
-        const transactionsByDay = transactionHistory.inMonthByDay(transaction.occurredAt().getMonth());
+        const transactionsByDay = transactionHistory.inMonthByDay(transaction.occurredAt());
         expect(transactionsByDay).toHaveLength(1);
         expect(transactionsByDay[0].date().getDate()).toBe(5);
         expect(transactionsByDay[0].transactions()).toEqual([transaction]);
@@ -31,7 +32,7 @@ describe('inMonthByDay', () => {
             transaction4
         ]);
         
-        const transactionsByDay = transactionHistory.inMonthByDay(transaction1.occurredAt().getMonth());
+        const transactionsByDay = transactionHistory.inMonthByDay(transaction1.occurredAt());
         expect(transactionsByDay).toHaveLength(3);
 
         expect(transactionsByDay[0].date().getDate()).toBe(7);
@@ -53,7 +54,7 @@ describe('inMonthByDay', () => {
             transaction2
         ]);
         
-        const transactionsByDay = transactionHistory.inMonthByDay(transaction1.occurredAt().getMonth());
+        const transactionsByDay = transactionHistory.inMonthByDay(transaction1.occurredAt());
         expect(transactionsByDay).toHaveLength(1);
         
         expect(transactionsByDay[0].date().getDate()).toBe(5);

--- a/src/mollybudget/transaction/model/TransactionHistory.test.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.test.js
@@ -15,17 +15,17 @@ describe('createWithRollover', () => {
         const transactionsByDay = transactionHistory.inMonthByDay(date);
         expect(transactionsByDay).toHaveLength(2);
 
-        expect(transactionsByDay[0].date().getDate()).toBe(1);
+        expect(transactionsByDay[0].date().getDate()).toBe(5);
         expect(transactionsByDay[0].transactions()).toHaveLength(1);
-        expect(transactionsByDay[0].transactions()[0].occurredAt().getDate()).toBe(1);
+        expect(transactionsByDay[0].transactions()[0].occurredAt().getDate()).toBe(5);
         expect(transactionsByDay[0].transactions()[0].amount()).toBeCloseTo(10.00);
-        expect(transactionsByDay[0].transactions()[0].category()).toBe('Rollover');
+        expect(transactionsByDay[0].transactions()[0].category()).toBe('General');
 
-        expect(transactionsByDay[1].date().getDate()).toBe(5);
+        expect(transactionsByDay[1].date().getDate()).toBe(1);
         expect(transactionsByDay[1].transactions()).toHaveLength(1);
-        expect(transactionsByDay[1].transactions()[0].occurredAt().getDate()).toBe(5);
+        expect(transactionsByDay[1].transactions()[0].occurredAt().getDate()).toBe(1);
         expect(transactionsByDay[1].transactions()[0].amount()).toBeCloseTo(10.00);
-        expect(transactionsByDay[1].transactions()[0].category()).toBe('General');
+        expect(transactionsByDay[1].transactions()[0].category()).toBe('Rollover');
     });
 });
 
@@ -78,17 +78,18 @@ describe('inMonthByDay', () => {
         const transactionsByDay = transactionHistory.inMonthByDay(may1);
         expect(transactionsByDay).toHaveLength(2);
 
-        expect(transactionsByDay[0].date().getDate()).toBe(1);
+        expect(transactionsByDay[0].date().getDate()).toBe(2);
         expect(transactionsByDay[0].transactions()).toHaveLength(1);
-        expect(transactionsByDay[0].transactions()[0].id()).toBe('rolloverId');
-        expect(transactionsByDay[0].transactions()[0].occurredAt().getDate()).toBe(1);
-        expect(transactionsByDay[0].transactions()[0].amount()).toBeCloseTo(111.10);
-        expect(transactionsByDay[0].transactions()[0].category()).toBe('Rollover');
+        expect(transactionsByDay[0].transactions()[0].occurredAt().getDate()).toBe(2);
+        expect(transactionsByDay[0].transactions()[0].amount()).toBeCloseTo(10.00);
+        expect(transactionsByDay[0].transactions()[0].category()).toBe('General');
 
+        expect(transactionsByDay[1].date().getDate()).toBe(1);
         expect(transactionsByDay[1].transactions()).toHaveLength(1);
-        expect(transactionsByDay[1].transactions()[0].occurredAt().getDate()).toBe(2);
-        expect(transactionsByDay[1].transactions()[0].amount()).toBeCloseTo(10.00);
-        expect(transactionsByDay[1].transactions()[0].category()).toBe('General');
+        expect(transactionsByDay[1].transactions()[0].id()).toBe('rolloverId');
+        expect(transactionsByDay[1].transactions()[0].occurredAt().getDate()).toBe(1);
+        expect(transactionsByDay[1].transactions()[0].amount()).toBeCloseTo(111.10);
+        expect(transactionsByDay[1].transactions()[0].category()).toBe('Rollover');
     });
 
     it('returns a single group of transactions if only one transaction exists in the given month', () => {
@@ -121,7 +122,7 @@ describe('inMonthByDay', () => {
         expect(transactionsByDay[0].transactions()).toEqual([transaction4]);
 
         expect(transactionsByDay[1].date().getDate()).toBe(6);
-        expect(transactionsByDay[1].transactions()).toEqual([transaction3, transaction2]);
+        expect(transactionsByDay[1].transactions()).toEqual([transaction2, transaction3]);
         
         expect(transactionsByDay[2].date().getDate()).toBe(5);
         expect(transactionsByDay[2].transactions()).toEqual([transaction1]);

--- a/src/mollybudget/transaction/model/TransactionHistory.test.js
+++ b/src/mollybudget/transaction/model/TransactionHistory.test.js
@@ -1,6 +1,33 @@
 import TransactionHistory from 'mollybudget/transaction/model/TransactionHistory';
 import Transaction from 'mollybudget/transaction/model/Transaction';
+import Budget from 'mollybudget/budget/model/Budget';
+import DailyBudget from 'mollybudget/settings/model/DailyBudget';
 
+
+describe('createWithRollover', () => {
+    it('uses the given budget to determine the rollover at the beginning of the month', () => {
+        const date = new Date('2018-05-05T11:24:12.000Z');
+        const transaction = new Transaction('tId1', 10.00, date, 'General');
+        const dailyBudget = new DailyBudget('dId1', 10.00, new Date('2018-04-30T11:24:12.000Z'));
+        const budget = new Budget([dailyBudget], [transaction]);
+        const transactionHistory = TransactionHistory.createWithRollover(date, [transaction], budget);
+        
+        const transactionsByDay = transactionHistory.inMonthByDay(date);
+        expect(transactionsByDay).toHaveLength(2);
+
+        expect(transactionsByDay[0].date().getDate()).toBe(1);
+        expect(transactionsByDay[0].transactions()).toHaveLength(1);
+        expect(transactionsByDay[0].transactions()[0].occurredAt().getDate()).toBe(1);
+        expect(transactionsByDay[0].transactions()[0].amount()).toBeCloseTo(10.00);
+        expect(transactionsByDay[0].transactions()[0].category()).toBe('Rollover');
+
+        expect(transactionsByDay[1].date().getDate()).toBe(5);
+        expect(transactionsByDay[1].transactions()).toHaveLength(1);
+        expect(transactionsByDay[1].transactions()[0].occurredAt().getDate()).toBe(5);
+        expect(transactionsByDay[1].transactions()[0].amount()).toBeCloseTo(10.00);
+        expect(transactionsByDay[1].transactions()[0].category()).toBe('General');
+    });
+});
 
 describe('inMonthByDay', () => {
     it('returns an empty array when there are no transactions', () => {
@@ -15,8 +42,8 @@ describe('inMonthByDay', () => {
         
         const transactionsByDay = transactionHistory.inMonthByDay(date);
         expect(transactionsByDay).toHaveLength(1);
-        expect(transactionsByDay[0].date().getDate()).toBe(1);
 
+        expect(transactionsByDay[0].date().getDate()).toBe(1);
         expect(transactionsByDay[0].transactions()).toHaveLength(1);
         expect(transactionsByDay[0].transactions()[0].occurredAt().getDate()).toBe(1);
         expect(transactionsByDay[0].transactions()[0].amount()).toBeCloseTo(123.12);
@@ -30,8 +57,8 @@ describe('inMonthByDay', () => {
         
         const transactionsByDay = transactionHistory.inMonthByDay(may1);
         expect(transactionsByDay).toHaveLength(1);
+
         expect(transactionsByDay[0].date().getDate()).toBe(1);
-        
         expect(transactionsByDay[0].transactions()).toHaveLength(2);
         expect(transactionsByDay[0].transactions()[0].occurredAt().getDate()).toBe(1);
         expect(transactionsByDay[0].transactions()[0].amount()).toBeCloseTo(111.10);
@@ -50,8 +77,8 @@ describe('inMonthByDay', () => {
         
         const transactionsByDay = transactionHistory.inMonthByDay(may1);
         expect(transactionsByDay).toHaveLength(2);
+
         expect(transactionsByDay[0].date().getDate()).toBe(1);
-        
         expect(transactionsByDay[0].transactions()).toHaveLength(1);
         expect(transactionsByDay[0].transactions()[0].occurredAt().getDate()).toBe(1);
         expect(transactionsByDay[0].transactions()[0].amount()).toBeCloseTo(111.10);

--- a/src/mollybudget/transaction/ui/CategoryIconMapper.js
+++ b/src/mollybudget/transaction/ui/CategoryIconMapper.js
@@ -6,6 +6,7 @@ export default class CategoryIconMapper {
             case 'Car' : return 'car';
             case 'Groceries' : return 'shopping-cart';
             case 'Income' : return 'money';
+            case 'Rollover' : return 'angle-double-right';
             default: return 'question';
         }
     }

--- a/src/mollybudget/transaction/ui/CategoryIconMapper.test.js
+++ b/src/mollybudget/transaction/ui/CategoryIconMapper.test.js
@@ -23,6 +23,10 @@ describe('toIcon', () => {
     });
 
     it('returns the question icon for an unknown category', () => {
+        expect(CategoryIconMapper.toIcon('Rollover')).toBe('angle-double-right');
+    });
+
+    it('returns the question icon for an unknown category', () => {
         expect(CategoryIconMapper.toIcon('Barf')).toBe('question');
     });
 });

--- a/src/mollybudget/transaction/ui/TransactionRoutes.js
+++ b/src/mollybudget/transaction/ui/TransactionRoutes.js
@@ -44,7 +44,7 @@ class TransactionRoutes extends React.Component {
 
     _transactionsIndexView() {
         return new TransactionsIndexView(
-            (new Date()).getMonth(),
+            this.props.dateSnapshot.getMonth(),
             new TransactionHistory(
                 this.props.transactionStore.transactions()
             )
@@ -54,6 +54,7 @@ class TransactionRoutes extends React.Component {
 
 TransactionRoutes.propTypes = {
     transactionStore: PropTypes.object.isRequired,
+    dateSnapshot: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired
 };
 

--- a/src/mollybudget/transaction/ui/TransactionRoutes.js
+++ b/src/mollybudget/transaction/ui/TransactionRoutes.js
@@ -44,8 +44,10 @@ class TransactionRoutes extends React.Component {
     _transactionsIndexView() {
         return new TransactionsIndexView(
             this.props.dateSnapshot,
-            new TransactionHistory(
-                this.props.transactionStore.transactions()
+            TransactionHistory.createWithRollover(
+                this.props.dateSnapshot,
+                this.props.transactionStore.transactions(),
+                this.props.budget
             )
         );
     }

--- a/src/mollybudget/transaction/ui/TransactionRoutes.js
+++ b/src/mollybudget/transaction/ui/TransactionRoutes.js
@@ -55,6 +55,7 @@ class TransactionRoutes extends React.Component {
 
 TransactionRoutes.propTypes = {
     transactionStore: PropTypes.object.isRequired,
+    budget: PropTypes.object.isRequired,
     dateSnapshot: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired
 };

--- a/src/mollybudget/transaction/ui/TransactionRoutes.js
+++ b/src/mollybudget/transaction/ui/TransactionRoutes.js
@@ -12,7 +12,7 @@ import TransactionHistory from 'mollybudget/transaction/model/TransactionHistory
 import ValueStore from 'mollybudget/common/model/ValueStore';
 
 
-class TransactionRoutesPage extends React.Component {
+class TransactionRoutes extends React.Component {
     constructor(props) {
         super(props);
 
@@ -52,9 +52,9 @@ class TransactionRoutesPage extends React.Component {
     }
 }
 
-TransactionRoutesPage.propTypes = {
+TransactionRoutes.propTypes = {
     transactionStore: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired
 };
 
-export default observer(TransactionRoutesPage);
+export default observer(TransactionRoutes);

--- a/src/mollybudget/transaction/ui/TransactionRoutes.js
+++ b/src/mollybudget/transaction/ui/TransactionRoutes.js
@@ -44,7 +44,7 @@ class TransactionRoutes extends React.Component {
 
     _transactionsIndexView() {
         return new TransactionsIndexView(
-            this.props.dateSnapshot.getMonth(),
+            this.props.dateSnapshot,
             new TransactionHistory(
                 this.props.transactionStore.transactions()
             )

--- a/src/mollybudget/transaction/ui/TransactionRoutes.js
+++ b/src/mollybudget/transaction/ui/TransactionRoutes.js
@@ -5,10 +5,9 @@ import { Switch, Route } from 'react-router-dom';
 
 import TransactionsIndexPage from 'mollybudget/transaction/ui/TransactionsIndexPage';
 import TransactionAmountPage from 'mollybudget/transaction/ui/TransactionAmountPage';
-
 import TransactionsIndexView from 'mollybudget/transaction/ui/TransactionsIndexView';
 import TransactionHistory from 'mollybudget/transaction/model/TransactionHistory';
-
+import Budget from 'mollybudget/budget/model/Budget';
 import ValueStore from 'mollybudget/common/model/ValueStore';
 
 

--- a/src/mollybudget/transaction/ui/TransactionRoutes.js
+++ b/src/mollybudget/transaction/ui/TransactionRoutes.js
@@ -7,7 +7,7 @@ import TransactionsIndexPage from 'mollybudget/transaction/ui/TransactionsIndexP
 import TransactionAmountPage from 'mollybudget/transaction/ui/TransactionAmountPage';
 import TransactionsIndexView from 'mollybudget/transaction/ui/TransactionsIndexView';
 import TransactionHistory from 'mollybudget/transaction/model/TransactionHistory';
-import Budget from 'mollybudget/budget/model/Budget';
+
 import ValueStore from 'mollybudget/common/model/ValueStore';
 
 

--- a/src/mollybudget/transaction/ui/TransactionRoutes.test.js
+++ b/src/mollybudget/transaction/ui/TransactionRoutes.test.js
@@ -10,10 +10,12 @@ import TransactionsIndexPage from 'mollybudget/transaction/ui/TransactionsIndexP
 describe('TransactionRoutes', () => {
     it('renders TransactionsIndexPage when the user navigates to /transactions', () => {
         const transactionStore = { transactions: jest.fn(() => []) };
+        const budget = { totalToDate: jest.fn(() => 100.00) };
         const wrapper = mount(
             <MemoryRouter initialEntries={['/transactions']}>
                 <TransactionRoutes
                     transactionStore={transactionStore}
+                    budget={budget}
                     dateSnapshot={new Date()}
                     history={{}}
                     location={{}}
@@ -25,10 +27,12 @@ describe('TransactionRoutes', () => {
     });
 
     it('renders TransactionAmountPage when the user navigates to /transactions/new', () => {
+        const budget = { totalToDate: jest.fn(() => 100.00) };
         const wrapper = mount(
             <MemoryRouter initialEntries={['/transactions/new']}>
                 <TransactionRoutes
                     transactionStore={{}}
+                    budget={budget}
                     dateSnapshot={new Date()}
                     history={{}}
                     location={{}}

--- a/src/mollybudget/transaction/ui/TransactionRoutes.test.js
+++ b/src/mollybudget/transaction/ui/TransactionRoutes.test.js
@@ -12,7 +12,12 @@ describe('TransactionRoutes', () => {
         const transactionStore = { transactions: jest.fn(() => []) };
         const wrapper = mount(
             <MemoryRouter initialEntries={['/transactions']}>
-                <TransactionRoutes transactionStore={transactionStore} history={{}} location={{}}/>
+                <TransactionRoutes
+                    transactionStore={transactionStore}
+                    dateSnapshot={new Date()}
+                    history={{}}
+                    location={{}}
+                />
             </MemoryRouter>
         );
         expect(wrapper.find(TransactionAmountPage)).toHaveLength(0);
@@ -22,7 +27,12 @@ describe('TransactionRoutes', () => {
     it('renders TransactionAmountPage when the user navigates to /transactions/new', () => {
         const wrapper = mount(
             <MemoryRouter initialEntries={['/transactions/new']}>
-                <TransactionRoutes transactionStore={{}} history={{}} location={{}}/>
+                <TransactionRoutes
+                    transactionStore={{}}
+                    dateSnapshot={new Date()}
+                    history={{}}
+                    location={{}}
+                />
             </MemoryRouter>
         );
         expect(wrapper.find(TransactionAmountPage)).toHaveLength(1);

--- a/src/mollybudget/transaction/ui/TransactionsIndexPage.js
+++ b/src/mollybudget/transaction/ui/TransactionsIndexPage.js
@@ -10,11 +10,7 @@ import 'mollybudget/common/ui/Page.css';
 
 class TransactionsIndexPage extends React.Component {
     render() {
-        if(this.props.transactionsIndexView.transactionDayViews().length > 0) {
-            return this._transactionsTable();
-        } else {
-            return this._noTransactionsMessage();
-        }
+        return this._transactionsTable();
     }
 
     _transactionsTable() {
@@ -27,14 +23,6 @@ class TransactionsIndexPage extends React.Component {
                 </Table>
             </section>
         );
-    }
-
-    _noTransactionsMessage() {
-        return(
-            <section className="Page">
-                <p className="lead">You haven't added any transactions.</p>
-            </section>
-        )
     }
 
     _transactionRowsByDay() {

--- a/src/mollybudget/transaction/ui/TransactionsIndexPage.test.js
+++ b/src/mollybudget/transaction/ui/TransactionsIndexPage.test.js
@@ -33,11 +33,11 @@ describe('TransactionsIndexPage', () => {
         
         expect(cols.at(1).children().props().name).toBe('dollar');
         expect(cols.at(2).text()).toBe('General');
-        expect(cols.at(3).text()).toBe('$40.00');
+        expect(cols.at(3).text()).toBe('$30.00');
 
         expect(cols.at(4).children().props().name).toBe('dollar');
         expect(cols.at(5).text()).toBe('General');
-        expect(cols.at(6).text()).toBe('$30.00');
+        expect(cols.at(6).text()).toBe('$40.00');
         
         expect(cols.at(8).text()).toBe('Total');
         expect(cols.at(9).text()).toBe('$70.00');

--- a/src/mollybudget/transaction/ui/TransactionsIndexPage.test.js
+++ b/src/mollybudget/transaction/ui/TransactionsIndexPage.test.js
@@ -95,18 +95,4 @@ describe('TransactionsIndexPage', () => {
         expect(cols.at(6).hasClass('TransactionsIndexPage-total--gain')).toBeTruthy();
         expect(cols.at(13).hasClass('TransactionsIndexPage-total--loss')).toBeTruthy();
     });
-
-    it('renders an informative message when there are no transactions', () => {
-        const transactionHistory = new TransactionHistory([]);
-        const transactionsIndexView = new TransactionsIndexView(
-            new Date(),
-            transactionHistory
-        );
-
-        const transactionsIndexPage = shallow(
-            <TransactionsIndexPage transactionsIndexView={transactionsIndexView}
-        />);
-
-        expect(transactionsIndexPage.find('p').text()).toBe("You haven't added any transactions.");
-    });
 });

--- a/src/mollybudget/transaction/ui/TransactionsIndexPage.test.js
+++ b/src/mollybudget/transaction/ui/TransactionsIndexPage.test.js
@@ -16,7 +16,7 @@ describe('TransactionsIndexPage', () => {
         const transaction3 = new Transaction('id3', 40.00, new Date('2018-03-06T11:25:12.000Z'), 'General');
         const transactionHistory = new TransactionHistory([transaction1, transaction2, transaction3]);
         const transactionsIndexView = new TransactionsIndexView(
-            transaction1.occurredAt().getMonth(),
+            transaction1.occurredAt(),
             transactionHistory
         );
 
@@ -55,7 +55,7 @@ describe('TransactionsIndexPage', () => {
         const income = new Transaction('id2', 30.00, new Date('2018-03-06T11:24:12.000Z'), 'Income');
         const transactionHistory = new TransactionHistory([expense, income]);
         const transactionsIndexView = new TransactionsIndexView(
-            expense.occurredAt().getMonth(),
+            expense.occurredAt(),
             transactionHistory
         );
 
@@ -77,7 +77,7 @@ describe('TransactionsIndexPage', () => {
         const income = new Transaction('id2', 30.00, new Date('2018-03-06T11:24:12.000Z'), 'Income');
         const transactionHistory = new TransactionHistory([expense, income]);
         const transactionsIndexView = new TransactionsIndexView(
-            expense.occurredAt().getMonth(),
+            expense.occurredAt(),
             transactionHistory
         );
 
@@ -93,7 +93,7 @@ describe('TransactionsIndexPage', () => {
     it('renders an informative message when there are no transactions', () => {
         const transactionHistory = new TransactionHistory([]);
         const transactionsIndexView = new TransactionsIndexView(
-            4,
+            new Date(),
             transactionHistory
         );
 

--- a/src/mollybudget/transaction/ui/TransactionsIndexPage.test.js
+++ b/src/mollybudget/transaction/ui/TransactionsIndexPage.test.js
@@ -21,8 +21,10 @@ describe('TransactionsIndexPage', () => {
         );
 
         const transactionsIndexPage = shallow(
-            <TransactionsIndexPage transactionsIndexView={transactionsIndexView}
-        />);
+            <TransactionsIndexPage
+                transactionsIndexView={transactionsIndexView}
+            />
+        );
         
         const cols = transactionsIndexPage.find('td');
         expect(cols).toHaveLength(17);
@@ -60,8 +62,10 @@ describe('TransactionsIndexPage', () => {
         );
 
         const transactionsIndexPage = shallow(
-            <TransactionsIndexPage transactionsIndexView={transactionsIndexView}
-        />);
+            <TransactionsIndexPage
+                transactionsIndexView={transactionsIndexView}
+            />
+        );
         
         const cols = transactionsIndexPage.find('td');
     
@@ -82,8 +86,10 @@ describe('TransactionsIndexPage', () => {
         );
 
         const transactionsIndexPage = shallow(
-            <TransactionsIndexPage transactionsIndexView={transactionsIndexView}
-        />);
+            <TransactionsIndexPage
+                transactionsIndexView={transactionsIndexView}
+            />
+        );
         
         const cols = transactionsIndexPage.find('td');
         expect(cols.at(6).hasClass('TransactionsIndexPage-total--gain')).toBeTruthy();

--- a/src/mollybudget/transaction/ui/TransactionsIndexView.js
+++ b/src/mollybudget/transaction/ui/TransactionsIndexView.js
@@ -6,13 +6,13 @@ import { formatCurrency } from 'mollybudget/format/CurrencyFormat';
 
 
 export default class TransactionsIndexView {
-    constructor(month, transactionHistory) {
-        this._month = month;
+    constructor(date, transactionHistory) {
+        this._date = date;
         this._transactionHistory = transactionHistory;
     }
 
     transactionDayViews() {
-        return this._transactionHistory.inMonthByDay(this._month).map(
+        return this._transactionHistory.inMonthByDay(this._date).map(
             (transactionsOnDay) => new TransactionDayView(transactionsOnDay)
         );
     }

--- a/src/mollybudget/transaction/ui/TransactionsIndexView.test.js
+++ b/src/mollybudget/transaction/ui/TransactionsIndexView.test.js
@@ -11,7 +11,7 @@ describe('TransactionsIndexView', () => {
             const transaction = new Transaction('id1', 20.00, new Date('2018-03-05T11:24:12.000Z'), 'General');
             const transactionHistory = new TransactionHistory([transaction]);
             const transactionsIndexView = new TransactionsIndexView(
-                transaction.occurredAt().getMonth(),
+                transaction.occurredAt(),
                 transactionHistory
             );
             


### PR DESCRIPTION
As a user, I want my monthly balance to rollover the transactions page, so that I can continue to stay on budget as each month passes by. 

Acceptance Criteria:
* View Past Transactions should show June 1st of {icon} Monthly Rollover $-297

Other notes:
* Transactions within each day are displayed from oldest to newest