### PR TITLE
Update authDomain with custom domain

### DIFF
--- a/src/mollybudget/network/FirebaseConfigProvider.js
+++ b/src/mollybudget/network/FirebaseConfigProvider.js
@@ -18,7 +18,7 @@ export default class FirebaseConfigProvider {
     _developmentConfig() {
         return {
             apiKey: "AIzaSyCnUdXPav7xCIxR-pG7qlGfHwiCOAjnFmY",
-            authDomain: "molly-budget-development.firebaseapp.com",
+            authDomain: "app.development.mollybudget.com",
             databaseURL: "https://molly-budget-development.firebaseio.com",
             projectId: "molly-budget-development",
             storageBucket: "molly-budget-development.appspot.com",
@@ -29,7 +29,7 @@ export default class FirebaseConfigProvider {
     _testConfig() {
         return {
             apiKey: "AIzaSyCUu0Nh7x5-XP2KK2F2ehVFtm1F54lmzHM",
-            authDomain: "molly-budget-test.firebaseapp.com",
+            authDomain: "app.test.mollybudget.com",
             databaseURL: "https://molly-budget-test.firebaseio.com",
             projectId: "molly-budget-test",
             storageBucket: "molly-budget-test.appspot.com",
@@ -40,7 +40,7 @@ export default class FirebaseConfigProvider {
     _productionConfig() {
         return {
             apiKey: "AIzaSyCx_fy73W9aopr9CZZYthjMUY6U1MX4-MU",
-            authDomain: "molly-budget.firebaseapp.com",
+            authDomain: "app.mollybudget.com",
             databaseURL: "https://molly-budget.firebaseio.com",
             projectId: "molly-budget",
             storageBucket: "molly-budget.appspot.com",

--- a/src/mollybudget/network/FirebaseConfigProvider.test.js
+++ b/src/mollybudget/network/FirebaseConfigProvider.test.js
@@ -31,7 +31,7 @@ describe('getConfig', () => {
 function _developmentConfig() {
     return {
         apiKey: "AIzaSyCnUdXPav7xCIxR-pG7qlGfHwiCOAjnFmY",
-        authDomain: "molly-budget-development.firebaseapp.com",
+        authDomain: "app.development.mollybudget.com",
         databaseURL: "https://molly-budget-development.firebaseio.com",
         projectId: "molly-budget-development",
         storageBucket: "molly-budget-development.appspot.com",
@@ -42,7 +42,7 @@ function _developmentConfig() {
 function _testConfig() {
     return {
         apiKey: "AIzaSyCUu0Nh7x5-XP2KK2F2ehVFtm1F54lmzHM",
-        authDomain: "molly-budget-test.firebaseapp.com",
+        authDomain: "app.test.mollybudget.com",
         databaseURL: "https://molly-budget-test.firebaseio.com",
         projectId: "molly-budget-test",
         storageBucket: "molly-budget-test.appspot.com",
@@ -53,7 +53,7 @@ function _testConfig() {
 function _productionConfig() {
     return {
         apiKey: "AIzaSyCx_fy73W9aopr9CZZYthjMUY6U1MX4-MU",
-        authDomain: "molly-budget.firebaseapp.com",
+        authDomain: "app.mollybudget.com",
         databaseURL: "https://molly-budget.firebaseio.com",
         projectId: "molly-budget",
         storageBucket: "molly-budget.appspot.com",


### PR DESCRIPTION
I've configured an official domain for MollyBudget now:
* app.development.mollybudget.com
* app.test.mollybudget.com
* app.mollybudget.com

This PR updates the authDomain setting so that we can authenticate properly against these domains.